### PR TITLE
Add GameObjectContainer

### DIFF
--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -152,4 +152,4 @@ class GameObjectContainer:
         self.all.remove(game_object)
         self.kinds[type(game_object)].remove(game_object)
         for s in self.tags.values():
-            s.remove(game_object)
+            s.discard(game_object)

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -1,5 +1,8 @@
 from collections import defaultdict
 from itertools import chain
+from typing import Any
+from typing import Iterable
+from typing import Iterator
 
 from ppb.abc import Scene
 from pygame import MOUSEBUTTONUP, QUIT
@@ -39,9 +42,21 @@ class GameObjectContainer:
 
     def __init__(self):
         self.all = set()
-
-    def add(self, game_object):
-        self.all.add(game_object)
+        self.kinds = defaultdict(set)
+        self.tags = defaultdict(set)
 
     def __contains__(self, item):
         return item in self.all
+
+    def add(self, game_object: Any, tags: Iterable=()):
+        self.all.add(game_object)
+        self.kinds[type(game_object)].add(game_object)
+        for tag in tags:
+            self.tags[tag].add(game_object)
+
+    def get(self, *, kind=None, tag=None) -> Iterator:
+        if kind is None and tag is None:
+            raise TypeError("get() takes at least one keyword-only argument. 'kind' or 'tag'.")
+        kinds = self.kinds[kind] or self.all
+        tags = self.tags[tag] or self.all
+        return (x for x in kinds.intersection(tags))

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -39,16 +39,55 @@ class BaseScene(Scene):
         return self.running, {"scene_class": self.next}
 
     def add(self, game_object: Hashable, tags: Iterable=())-> None:
+        """
+        Add a game_object to the scene.
+
+        game_object: Any GameObject object. The item to be added.
+        tags: An iterable of Hashable objects. Values that can be used to
+              retrieve a group containing the game_object.
+
+        Examples:
+            scene.add(MyGameObject())
+
+            scene.add(MyGameObject(), tags=("red", "blue")
+        """
         self.game_objects.add(game_object, tags)
 
     def get(self, *, kind: Type=None, tag: Hashable=None, **kwargs) -> Iterator:
+        """
+        Get an iterator of GameObjects by kind or tag.
+
+        kind: Any type. Pass to get a subset of contained GameObjects with the
+              given type.
+        tag: Any Hashable object. Pass to get a subset of contained GameObjects
+             with the given tag.
+
+        Pass both kind and tag to get objects that are both that type and that
+        tag.
+
+        Examples:
+            scene.get(type=MyGameObject)
+
+            scene.get(tag="red")
+
+            scene.get(type=MyGameObject, tag="red")
+        """
         return self.game_objects.get(kind=kind, tag=tag, **kwargs)
 
     def remove(self, game_object: Hashable) -> None:
+        """
+        Remove the given object from the scene.
+
+        game_object: A game object.
+
+        Example:
+            scene.remove(my_game_object)
+        """
         self.game_objects.remove(game_object)
 
 
 class GameObjectContainer:
+    """A container for game objects."""
 
     def __init__(self):
         self.all = set()
@@ -59,12 +98,42 @@ class GameObjectContainer:
         return item in self.all
 
     def add(self, game_object: Hashable, tags: Iterable[Hashable]=()) -> None:
+        """
+        Add a game_object to the container.
+
+        game_object: Any Hashable object. The item to be added.
+        tags: An iterable of Hashable objects. Values that can be used to
+              retrieve a group containing the game_object.
+
+        Examples:
+            container.add(MyObject())
+
+            container.add(MyObject(), tags=("red", "blue")
+        """
         self.all.add(game_object)
         self.kinds[type(game_object)].add(game_object)
         for tag in tags:
             self.tags[tag].add(game_object)
 
     def get(self, *, kind: Type=None, tag: Hashable=None, **_) -> Iterator:
+        """
+        Get an iterator of objects by kind or tag.
+
+        kind: Any type. Pass to get a subset of contained items with the given
+              type.
+        tag: Any Hashable object. Pass to get a subset of contained items with
+             the given tag.
+
+        Pass both kind and tag to get objects that are both that type and that
+        tag.
+
+        Examples:
+            container.get(type=MyObject)
+
+            container.get(tag="red")
+
+            container.get(type=MyObject, tag="red")
+        """
         if kind is None and tag is None:
             raise TypeError("get() takes at least one keyword-only argument. 'kind' or 'tag'.")
         kinds = self.kinds[kind] or self.all
@@ -72,6 +141,14 @@ class GameObjectContainer:
         return (x for x in kinds.intersection(tags))
 
     def remove(self, game_object: Hashable) -> None:
+        """
+        Remove the given object from the container.
+
+        game_object: A hashable contained by container.
+
+        Example:
+            container.remove(myObject)
+        """
         self.all.remove(game_object)
         self.kinds[type(game_object)].remove(game_object)
         for s in self.tags.values():

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -15,25 +15,15 @@ class BaseScene(Scene):
         self.background.fill(self.background_color)
         self.groups = defaultdict(LayeredDirty)
         self.render_group = LayeredDirty()
-        self.callback_map = {
-            QUIT: self.__quit__,
-            MOUSEBUTTONUP: self.__mouse_up__
-        }
 
     def render(self):
         window = self.engine.display
         self.render_group.add(chain(g.sprites() for g in self.groups.values()))
         return self.render_group.draw(window, self.background)
 
-    def handle_event(self, event):
-        self.callback_map.get(event.type, self.__null__)(event)
-
-    def publish_event(self, event):
-        pass
-
     def simulate(self, time_delta: float):
         for group in list(self.groups.values()):
-            group.update(time_delta)
+            group.update(self, time_delta)
 
     def change(self):
         """
@@ -41,13 +31,17 @@ class BaseScene(Scene):
         """
         return self.running, {"scene_class": self.next}
 
-    def __null__(self, event):
+    def add(self, game_object):
         pass
 
-    def __quit__(self, event):
-        _ = event
-        self.running = False
-        self.quit = True
 
-    def __mouse_up__(self, event):
-        pass
+class GameObjectContainer:
+
+    def __init__(self):
+        self.all = set()
+
+    def add(self, game_object):
+        self.all.add(game_object)
+
+    def __contains__(self, item):
+        return item in self.all

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 from pytest import fixture
 from pytest import mark
 from pytest import raises
@@ -18,24 +20,6 @@ class TestSprite:
     pass
 
 
-# TODO: Make this mocking unnecessary
-class NullEngine:
-    def __init__(self):
-        self.display = Copyable()
-
-
-class Copyable:
-
-    def copy(self):
-        return Fillable()
-
-
-class Fillable:
-
-    def fill(self, *args):
-        pass
-
-
 @fixture()
 def player():
     return TestPlayer()
@@ -46,7 +30,7 @@ def enemies():
     return TestEnemy(), TestEnemy()
 
 
-@mark.parametrize("container", (GameObjectContainer(), BaseScene(NullEngine())))
+@mark.parametrize("container", (GameObjectContainer(), BaseScene(Mock())))
 def test_add_methods(container, player, enemies):
     container.add(player)
     for group, sprite in zip(("red", "blue"), enemies):
@@ -56,7 +40,7 @@ def test_add_methods(container, player, enemies):
         assert enemy in container
 
 
-@mark.parametrize("container", (GameObjectContainer(), BaseScene(NullEngine())))
+@mark.parametrize("container", (GameObjectContainer(), BaseScene(Mock())))
 def test_get_methods(container, player, enemies):
 
     sprite = TestSprite()
@@ -87,8 +71,8 @@ def test_get_methods(container, player, enemies):
         container.get()
 
 
-@mark.parametrize("container", (GameObjectContainer(), BaseScene(NullEngine())))
-def test_game_object_container__remove(container, player):
+@mark.parametrize("container", (GameObjectContainer(), BaseScene(Mock())))
+def test_remove_methods(container, player):
     container.add(player, "test")
     assert player in container
     container.remove(player)

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -20,6 +20,11 @@ class TestSprite:
     pass
 
 
+def containers():
+    yield GameObjectContainer()
+    yield BaseScene(Mock())
+
+
 @fixture()
 def player():
     return TestPlayer()
@@ -30,7 +35,7 @@ def enemies():
     return TestEnemy(), TestEnemy()
 
 
-@mark.parametrize("container", (GameObjectContainer(), BaseScene(Mock())))
+@mark.parametrize("container", containers())
 def test_add_methods(container, player, enemies):
     container.add(player)
     for group, sprite in zip(("red", "blue"), enemies):
@@ -40,7 +45,7 @@ def test_add_methods(container, player, enemies):
         assert enemy in container
 
 
-@mark.parametrize("container", (GameObjectContainer(), BaseScene(Mock())))
+@mark.parametrize("container", containers())
 def test_get_methods(container, player, enemies):
 
     sprite = TestSprite()
@@ -71,11 +76,20 @@ def test_get_methods(container, player, enemies):
         container.get()
 
 
-@mark.parametrize("container", (GameObjectContainer(), BaseScene(Mock())))
-def test_remove_methods(container, player):
+@mark.parametrize("container", containers())
+def test_remove_methods(container, player, enemies):
     container.add(player, "test")
+    container.add(enemies[0], "test")
+    container.add(enemies[1], "blue")
     assert player in container
+    assert enemies[0] in container
+    assert enemies[1] in container
+
     container.remove(player)
+
     assert player not in container
     assert player not in container.get(kind=TestPlayer)
     assert player not in container.get(tag="test")
+    assert enemies[0] in container
+    assert enemies[0] in container.get(tag="test")
+    assert enemies[1] in container

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,0 +1,64 @@
+from pytest import raises, fixture
+
+from ppb.scenes import GameObjectContainer
+
+
+class TestEnemy:
+    pass
+
+
+class TestPlayer:
+    pass
+
+
+class TestSprite:
+    pass
+
+
+@fixture()
+def container():
+    return GameObjectContainer()
+
+
+def test_game_object_container__add(container):
+    player = TestPlayer()
+    container.add(player)
+    enemies = TestEnemy(), TestEnemy()
+    for group, sprite in zip(("red", "blue"), enemies):
+        container.add(sprite, [group])
+    assert player in container
+    for enemy in enemies:
+        assert enemy in container
+
+
+def test_game_object_container__get(container):
+
+    player = TestPlayer()
+    enemies = [TestEnemy(), TestEnemy()]
+    sprite = TestSprite()
+    container.add(player, ["red"])
+    container.add(enemies[0])
+    container.add(enemies[1], ["red"])
+    container.add(sprite)
+
+    enemy_set = set(container.get(type=TestEnemy))
+    assert len(enemy_set) == 2
+    for enemy in enemies:
+        assert enemy in enemy_set
+
+    player_set = set(container.get(type=TestPlayer))
+    assert len(player_set) == 1
+    assert player in player_set
+
+    sprite_set = set(container.get(type=TestSprite))
+    assert len(sprite_set) == 1
+    assert sprite in sprite_set
+
+    red_set = set(container.get(group="red"))
+    assert len(red_set) == 2
+    assert player in red_set
+    assert enemies[1] in red_set
+
+    with raises(TypeError):
+        container.get()
+

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,5 +1,8 @@
-from pytest import raises, fixture
+from pytest import fixture
+from pytest import mark
+from pytest import raises
 
+from ppb.scenes import BaseScene
 from ppb.scenes import GameObjectContainer
 
 
@@ -15,15 +18,37 @@ class TestSprite:
     pass
 
 
+# TODO: Make this mocking unnecessary
+class NullEngine:
+    def __init__(self):
+        self.display = Copyable()
+
+
+class Copyable:
+
+    def copy(self):
+        return Fillable()
+
+
+class Fillable:
+
+    def fill(self, *args):
+        pass
+
+
 @fixture()
-def container():
-    return GameObjectContainer()
+def player():
+    return TestPlayer()
 
 
-def test_game_object_container__add(container):
-    player = TestPlayer()
+@fixture()
+def enemies():
+    return TestEnemy(), TestEnemy()
+
+
+@mark.parametrize("container", (GameObjectContainer(), BaseScene(NullEngine())))
+def test_add_methods(container, player, enemies):
     container.add(player)
-    enemies = TestEnemy(), TestEnemy()
     for group, sprite in zip(("red", "blue"), enemies):
         container.add(sprite, [group])
     assert player in container
@@ -31,10 +56,9 @@ def test_game_object_container__add(container):
         assert enemy in container
 
 
-def test_game_object_container__get(container):
+@mark.parametrize("container", (GameObjectContainer(), BaseScene(NullEngine())))
+def test_get_methods(container, player, enemies):
 
-    player = TestPlayer()
-    enemies = [TestEnemy(), TestEnemy()]
     sprite = TestSprite()
     container.add(player, ["red"])
     container.add(enemies[0])
@@ -62,3 +86,12 @@ def test_game_object_container__get(container):
     with raises(TypeError):
         container.get()
 
+
+@mark.parametrize("container", (GameObjectContainer(), BaseScene(NullEngine())))
+def test_game_object_container__remove(container, player):
+    container.add(player, "test")
+    assert player in container
+    container.remove(player)
+    assert player not in container
+    assert player not in container.get(kind=TestPlayer)
+    assert player not in container.get(tag="test")

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -41,20 +41,20 @@ def test_game_object_container__get(container):
     container.add(enemies[1], ["red"])
     container.add(sprite)
 
-    enemy_set = set(container.get(type=TestEnemy))
+    enemy_set = set(container.get(kind=TestEnemy))
     assert len(enemy_set) == 2
     for enemy in enemies:
         assert enemy in enemy_set
 
-    player_set = set(container.get(type=TestPlayer))
+    player_set = set(container.get(kind=TestPlayer))
     assert len(player_set) == 1
     assert player in player_set
 
-    sprite_set = set(container.get(type=TestSprite))
+    sprite_set = set(container.get(kind=TestSprite))
     assert len(sprite_set) == 1
     assert sprite in sprite_set
 
-    red_set = set(container.get(group="red"))
+    red_set = set(container.get(tag="red"))
     assert len(red_set) == 2
     assert player in red_set
     assert enemies[1] in red_set


### PR DESCRIPTION
Adds a new container for game objects that includes features for quickly retrieving sets based on type and arbitrary tags.

Also includes the GameObjectContainer as part of a scene with passthrough methods.