### PR TITLE
Fix Backports in Wheel distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,6 @@ def readme():
     with open('README.md') as file:
         return file.read()
 
-backports = []
-
-if sys.version_info < (3, 7):
-    backports += ['dataclasses']
 
 setup(
     name='ppb',
@@ -18,7 +14,9 @@ setup(
     install_requires=[
         'pygame',
         'ppb-vector',
-    ] + backports,
+        'dataclasses; python_version < "3.7"'
+    ],
+    python_requires=">=3.6",
     url='https://github.com/ppb/pursuedpybear',
     license='Artistic-2.0',
     author='Piper Thunstrom',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def readme():
 
 setup(
     name='ppb',
-    version='0.4.0',
+    version='0.4.1',
     packages=['ppb'],
     install_requires=[
         'pygame',


### PR DESCRIPTION
The way we were handling backports previously would produce incorrect wheels, causing installation issues.

Fixes #149.

Unfortunately, I'm not sure how to test this other than "build a wheel and see if it installs".