### PR TITLE
[WIP] Interactive Shell

### DIFF
--- a/ppb/shell.py
+++ b/ppb/shell.py
@@ -21,6 +21,7 @@ class ReplThread(threading.Thread):
             "BaseScene": ppb.BaseScene,
             "BaseSprite": ppb.BaseSprite, 
             "current_scene": self.get_scene,
+            "signal": self.signal,
         }
 
     def signal(self, event):

--- a/ppb/shell.py
+++ b/ppb/shell.py
@@ -56,7 +56,7 @@ class ReplThread(threading.Thread):
     Vector, BaseSprite, BaseScene, ppb and several other things are imported.
 
     scene is preloaded with the starting scene. Defining things in the REPL show
-    up on the scene.
+    up on the scene. Event handlers work.
 
     current_scene() gets the current scene.
     signal() injects an event.

--- a/ppb/shell.py
+++ b/ppb/shell.py
@@ -107,4 +107,4 @@ with ppb.GameEngine(ppb.BaseScene) as eng:
     handler.output = repl.interject
     repl.start()
     eng.run()
-    print("Engine has quit")
+    repl.interject("Engine has quit")

--- a/ppb/shell.py
+++ b/ppb/shell.py
@@ -5,6 +5,7 @@ import threading
 import logging
 import readline
 import pathlib
+import textwrap
 
 
 class InteractiveConsole(code.InteractiveConsole):
@@ -23,7 +24,7 @@ class InteractiveConsole(code.InteractiveConsole):
              # readline.redisplay() doesn't seem to do anything
             + readline.get_line_buffer()
         )
-        
+
 
 class ReadlineHandler(logging.Handler):
     def __init__(self, *p, **kw):
@@ -46,6 +47,14 @@ class BaseSprite(ppb.BaseSprite):
 
 class ReplThread(threading.Thread):
     banner = """
+    PPB Interactive Console
+
+    Vector, BaseSprite, BaseScene, ppb and several other things are imported.
+
+    current_scene() gets the current scene.
+    signal() injects an event.
+
+    Type "help" for more information.
     """
     def __init__(self, engine):
         super().__init__(name='repl')
@@ -58,7 +67,12 @@ class ReplThread(threading.Thread):
             "__doc__": None,
             "Vector": ppb.Vector,
             "BaseScene": ppb.BaseScene,
-            "BaseSprite": BaseSprite, 
+            "BaseSprite": BaseSprite,
+            "DoNotRender": ppb.flags.DoNotRender,
+            "ppb": ppb,
+            "events": ppb.events,
+            "keycodes": ppb.keycodes,
+            "buttons": ppb.buttons,
             "current_scene": self.get_scene,
             "signal": self.signal,
         }
@@ -75,7 +89,7 @@ class ReplThread(threading.Thread):
         if sys.__interactivehook__ is not None:
             sys.__interactivehook__()
 
-        self.console.interact(banner=self.banner, exitmsg="")
+        self.console.interact(banner=textwrap.dedent(self.banner), exitmsg="")
         self.signal(ppb.events.Quit())
 
     def interject(self, text):

--- a/ppb/shell.py
+++ b/ppb/shell.py
@@ -1,0 +1,48 @@
+import sys
+import code
+import ppb
+import threading
+import logging
+
+
+class ReplThread(threading.Thread):
+    banner = """
+    """
+    def __init__(self, engine):
+        super().__init__(name='repl')
+        self.engine = engine
+        self.locals = self.build_locals()
+
+    def build_locals(self):
+        return {
+            "__name__": "__console__",
+            "__doc__": None,
+            "Vector": ppb.Vector,
+            "BaseScene": ppb.BaseScene,
+            "BaseSprite": ppb.BaseSprite, 
+            "current_scene": self.get_scene,
+        }
+
+    def signal(self, event):
+        self.engine.signal(event)
+
+    def get_scene(self):
+        return self.engine.current_scene
+
+    def run(self):
+        # Stolen from stdlib code.interact()
+        console = code.InteractiveConsole(self.locals)
+        if sys.__interactivehook__ is not None:
+            sys.__interactivehook__()
+
+        console.interact(banner=self.banner, exitmsg="")
+        self.signal(ppb.events.Quit())
+
+
+logging.basicConfig(level=logging.INFO)
+
+with ppb.GameEngine(ppb.BaseScene) as eng:
+    repl = ReplThread(eng)
+    repl.start()
+    eng.run()
+    print("Engine has quit")


### PR DESCRIPTION
Add a REPL mode, allowing you to interact with a live ppb engine.

TODO:
* [ ] Ctrl+C needs to interrupt the REPL, not the engine
* [ ] Better way to edit sprite/scene classes after the fact (including updating live objects)
* [ ] Do we want the repl itself to receive events?
* [ ] Interacting with the scene is awkward. Magic `scene` builtin that gets updated?
* [ ] Can we have `print()` be interjected somehow? Updating `sys.stdout` and `sys.stderr` is fraught and tricky (since `input()`, `readline`, etc use these as well)
* [ ] Do we want to use eg ipython if its available?
