### PR TITLE
New Class Attribute based sprites fail when size is changed in class definition.

### DIFF
--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -156,8 +156,7 @@ class BaseSprite(EventMixin):
     resource_path = None
     position: Vector = Vector(0, 0)
     facing: Vector = Vector(0, -1)
-    _size: Union[int, float] = 1
-    _offset_value = None
+    size: Union[int, float] = 1
 
     def __init__(self, **kwargs):
         super().__init__()
@@ -224,13 +223,8 @@ class BaseSprite(EventMixin):
         self.position.y = value - self._offset_value
 
     @property
-    def size(self) -> Union[int, float]:
-        return self._size
-
-    @size.setter
-    def size(self, value: Union[int, float]):
-        self._size = value
-        self._offset_value = self._size / 2
+    def _offset_value(self):
+        return self.size / 2
 
     def rotate(self, degrees: Number):
         self.facing.rotate(degrees)

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -290,4 +290,4 @@ def test_offset():
     class TestSprite(BaseSprite):
         size = 1.1
 
-    assert TestSprite().left < -1
+    assert TestSprite().left < -0.5

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -284,3 +284,10 @@ def test_class_attrs():
 
     sprite = TestSprite(position=(2, 4))
     assert sprite.position == Vector(2, 4)
+
+
+def test_offset():
+    class TestSprite(BaseSprite):
+        size = 1.1
+
+    assert TestSprite().left < -1


### PR DESCRIPTION
This is genuinely broken and prevented me from doing `self.left < x < self.right` inside an event handler.

For some reason, `Sprite._offset_value` doesn't get set properly:

```
Traceback (most recent call last):
  File "vpa_ppb.py", line 63, in <module>
    ge.run()
  File ".venv/lib/python3.7/site-packages/ppb/engine.py", line 79, in run
    self.main_loop()
  File ".venv/lib/python3.7/site-packages/ppb/engine.py", line 93, in main_loop
    self.publish()
  File ".venv/lib/python3.7/site-packages/ppb/engine.py", line 121, in publish
    game_object.__event__(event, self.signal)
  File ".venv/lib/python3.7/site-packages/ppb/events.py", line 76, in __event__
    meth(bag, fire_event)
  File "vpa_ppb.py", line 46, in on_button_pressed
    if self.left < x < self.right:
  File ".venv/lib/python3.7/site-packages/ppb/sprites.py", line 67, in __lt__
    return self.value < other
  File ".venv/lib/python3.7/site-packages/ppb/sprites.py", line 73, in value
    return self.parent.position[coordinate] + (offset * multiplier)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

Actual code:

```python
import ppb

WINDOW_WIDTH = 1100
WINDOW_HEIGHT = 600
GRID_SIZE = 100

class GridSquare(ppb.BaseSprite):
    size = 0.99
    image = None

    def on_button_pressed(self, press: events.ButtonPressed, signal):
        x = press.position.x / GRID_SIZE
        y = press.position.y / GRID_SIZE
        if self.left < x < self.right:
            print("Yoohoo!")


class Game(ppb.BaseScene):
    background_color = (241, 216, 162)
    spawn_chance = 360

    def __init__(self, engine):
        super().__init__(engine)
        self.main_camera.pixel_ratio = GRID_SIZE
        self.main_camera.position = ppb.Vector(WINDOW_WIDTH / 2 / GRID_SIZE, WINDOW_HEIGHT / 2 /GRID_SIZE)
        for x, y in product(range(2, 11), range(0, 5)):
            self.add(GridSquare(position=(x + 0.5, y + 0.5)))


with ppb.GameEngine(Game, resolution=(WINDOW_WIDTH, WINDOW_HEIGHT)) as ge:
    ge.run()
```

VERSION: 0.5.0rc2
PYTHON: 3.7.0