### PR TITLE
ppb/vector: Define __slots__

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -19,3 +19,4 @@ Name | Email | Twitter |
 [Dimitris Maroulidis](https://github.com/dmaroulidis) | [dimitris@dimitrismaroulidis.com](mailto:dimitris@dimitrismaroulidis.com) | [dmaroulidis](https://twitter.com/dmaroulidis)
 [Jenny Li](https://github.com/imjennyli) | 
 [Andrew Schamp](https://github.com/schamp/) | | [schamp](https://twitter.com/schamp)
+[Nicolas Braud-Santoni](https://nicolas.braud-santoni.eu) | | |

--- a/ppb/vector.py
+++ b/ppb/vector.py
@@ -2,4 +2,4 @@ from ppb_vector import Vector2
 
 
 class Vector(Vector2):
-    pass
+    __slots__ = ()


### PR DESCRIPTION
When used with a version of ppb-vector that defines `__slots__`, this dramatically reduces memory usage.

When used with an earlier version of ppb-vector, `__dict__` is accessible, making the change a no-op.

See https://github.com/ppb/ppb-vector/pull/115