### PR TITLE
New subsystem API

### DIFF
--- a/ppb/engine.py
+++ b/ppb/engine.py
@@ -36,7 +36,7 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
         self.event_extensions = defaultdict(dict)
         self.running = False
         self.entered = False
-        self.last_idle_event = None
+        self._last_idle_time = None
 
         # Systems
         self.systems_classes = systems
@@ -81,7 +81,7 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
 
     def start(self):
         self.running = True
-        self.last_idle_event = time.monotonic()
+        self._last_idle_time = time.monotonic()
         self.activate({"scene_class": self.first_scene,
                        "kwargs": self.scene_kwargs})
 
@@ -89,8 +89,8 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
         while self.running:
             time.sleep(0)
             now = time.monotonic()
-            self.signal(events.Idle(now - self.last_idle_event))
-            self.last_idle_event = now
+            self.signal(events.Idle(now - self._last_idle_time))
+            self._last_idle_time = now
             while self.events:
                 self.publish()
             self.manage_scene()

--- a/ppb/engine.py
+++ b/ppb/engine.py
@@ -91,15 +91,8 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
             now = time.monotonic()
             self.signal(events.Heartbeat(now - self.last_heartbeat))
             self.last_heartbeat = now
-            # Okay, doing this twice is hacky as hell, but fine while I remove
-            # the old system.
             while self.events:
                 self.publish()
-            for system in self.systems:
-                for event in system.activate(self):
-                    self.signal(event)
-                    while self.events:
-                        self.publish()
             self.manage_scene()
 
     def activate(self, next_scene: dict):

--- a/ppb/engine.py
+++ b/ppb/engine.py
@@ -36,7 +36,7 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
         self.event_extensions = defaultdict(dict)
         self.running = False
         self.entered = False
-        self.last_heartbeat = None
+        self.last_idle_event = None
 
         # Systems
         self.systems_classes = systems
@@ -81,7 +81,7 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
 
     def start(self):
         self.running = True
-        self.last_heartbeat = time.monotonic()
+        self.last_idle_event = time.monotonic()
         self.activate({"scene_class": self.first_scene,
                        "kwargs": self.scene_kwargs})
 
@@ -89,8 +89,8 @@ class GameEngine(Engine, EventMixin, LoggingMixin):
         while self.running:
             time.sleep(0)
             now = time.monotonic()
-            self.signal(events.Heartbeat(now - self.last_heartbeat))
-            self.last_heartbeat = now
+            self.signal(events.Idle(now - self.last_idle_event))
+            self.last_idle_event = now
             while self.events:
                 self.publish()
             self.manage_scene()

--- a/ppb/events.py
+++ b/ppb/events.py
@@ -272,6 +272,15 @@ class StopScene:
 
 
 @dataclass
+class Heartbeat:
+    """
+    An engine plumbing event to pump timing information to subsystems.
+    """
+    time_delta: float
+    scene: Scene = None
+
+
+@dataclass
 class Update:
     """
     Fired on game tick

--- a/ppb/events.py
+++ b/ppb/events.py
@@ -272,7 +272,7 @@ class StopScene:
 
 
 @dataclass
-class Heartbeat:
+class Idle:
     """
     An engine plumbing event to pump timing information to subsystems.
     """

--- a/ppb/systems/__init__.py
+++ b/ppb/systems/__init__.py
@@ -48,8 +48,8 @@ class Renderer(System):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pygame.quit()
 
-    def on_heartbeat(self, heartbeat_event: events.Heartbeat, signal):
-        self.render_clock += heartbeat_event.time_delta
+    def on_idle(self, idle_event: events.Idle, signal):
+        self.render_clock += idle_event.time_delta
         if self.render_ready:
             self.render_ready = False
             signal(events.Render())
@@ -152,13 +152,13 @@ class Updater(System):
     def __enter__(self):
         self.start_time = time.time()
 
-    def on_heartbeat(self, heartbeat_event, signal):
+    def on_idle(self, idle_event: events.Idle, signal):
         if self.last_tick is None:
             self.last_tick = time.time()
         this_tick = time.time()
         self.accumulated_time += this_tick - self.last_tick
         self.last_tick = this_tick
         while self.accumulated_time >= self.time_step:
-            # This might need to change for the heartbeat system to signal _only_ once per idle event.
+            # This might need to change for the Idle event system to signal _only_ once per idle event.
             self.accumulated_time += -self.time_step
             signal(events.Update(self.time_step))

--- a/ppb/systems/__init__.py
+++ b/ppb/systems/__init__.py
@@ -5,7 +5,6 @@ import pygame
 
 import ppb.events as events
 import ppb.flags as flags
-import ppb.utils as utils
 
 default_resolution = 800, 600
 
@@ -150,12 +149,12 @@ class Updater(System):
         self.time_step = time_step
 
     def __enter__(self):
-        self.start_time = time.time()
+        self.start_time = time.monotonic()
 
     def on_idle(self, idle_event: events.Idle, signal):
         if self.last_tick is None:
-            self.last_tick = time.time()
-        this_tick = time.time()
+            self.last_tick = time.monotonic()
+        this_tick = time.monotonic()
         self.accumulated_time += this_tick - self.last_tick
         self.last_tick = this_tick
         while self.accumulated_time >= self.time_step:

--- a/ppb/systems/__init__.py
+++ b/ppb/systems/__init__.py
@@ -5,6 +5,7 @@ import pygame
 
 import ppb.events as events
 import ppb.flags as flags
+import ppb.utils as utils
 
 default_resolution = 800, 600
 
@@ -20,16 +21,13 @@ class System(events.EventMixin):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def activate(self, engine):
-        return []
-
 
 from ppb.systems.pg import EventPoller as PygameEventPoller  # To not break old imports.
 
 
 class Renderer(System):
 
-    def __init__(self, resolution=default_resolution, window_title: str="PursuedPyBear", **kwargs):
+    def __init__(self, resolution=default_resolution, window_title: str="PursuedPyBear", target_frame_rate: int=30, **kwargs):
         self.resolution = resolution
         self.resources = {}
         self.window = None
@@ -37,6 +35,10 @@ class Renderer(System):
         self.pixel_ratio = None
         self.resized_images = {}
         self.old_resized_images = {}
+        self.render_clock = 0
+        self.render_ready = False
+        self.target_frame_rate = target_frame_rate
+        self.target_count = 1 / self.target_frame_rate
 
     def __enter__(self):
         pygame.init()
@@ -46,9 +48,18 @@ class Renderer(System):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pygame.quit()
 
-    def activate(self, engine):
-        yield events.PreRender()
-        yield events.Render()
+    def on_heartbeat(self, heartbeat_event: events.Heartbeat, signal):
+        self.render_clock += heartbeat_event.time_delta
+        if self.render_ready:
+            self.render_ready = False
+            signal(events.Render())
+        elif self.render_clock >= self.target_count:
+            self.render_clock = 0
+            signal(events.PreRender())
+
+    def on_pre_render(self, pre_render_event, signal):
+        # Here to let the system flush responses to PreRender before rendering.
+        self.render_ready = True
 
     def on_render(self, render_event, signal):
         self.render_background(render_event.scene)
@@ -141,12 +152,13 @@ class Updater(System):
     def __enter__(self):
         self.start_time = time.time()
 
-    def activate(self, engine):
+    def on_heartbeat(self, heartbeat_event, signal):
         if self.last_tick is None:
             self.last_tick = time.time()
         this_tick = time.time()
         self.accumulated_time += this_tick - self.last_tick
         self.last_tick = this_tick
         while self.accumulated_time >= self.time_step:
+            # This might need to change for the heartbeat system to signal _only_ once per idle event.
             self.accumulated_time += -self.time_step
-            yield events.Update(self.time_step)
+            signal(events.Update(self.time_step))

--- a/ppb/systems/pg.py
+++ b/ppb/systems/pg.py
@@ -155,11 +155,11 @@ class EventPoller(System):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pygame.quit()
 
-    def on_heartbeat(self, heartbeat, signal):
+    def on_idle(self, idle: events.Idle, signal):
         for pygame_event in pygame.event.get():
             methname = self.event_map.get(pygame_event.type)
             if methname is not None:  # Is there a handler for this pygame event?
-                ppbevent = getattr(self, methname)(pygame_event, heartbeat.scene)
+                ppbevent = getattr(self, methname)(pygame_event, idle.scene)
                 if ppbevent:  # Did the handler actually produce a ppb event?
                     signal(ppbevent)
 

--- a/ppb/systems/pg.py
+++ b/ppb/systems/pg.py
@@ -155,11 +155,11 @@ class EventPoller(System):
     def __exit__(self, exc_type, exc_val, exc_tb):
         pygame.quit()
 
-    def on_update(self, update, signal):
+    def on_heartbeat(self, heartbeat, signal):
         for pygame_event in pygame.event.get():
             methname = self.event_map.get(pygame_event.type)
             if methname is not None:  # Is there a handler for this pygame event?
-                ppbevent = getattr(self, methname)(pygame_event, update.scene)
+                ppbevent = getattr(self, methname)(pygame_event, heartbeat.scene)
                 if ppbevent:  # Did the handler actually produce a ppb event?
                     signal(ppbevent)
 

--- a/ppb/testutils.py
+++ b/ppb/testutils.py
@@ -2,7 +2,7 @@ import time
 from typing import Callable
 
 from ppb.engine import GameEngine
-from ppb.events import Heartbeat
+from ppb.events import Idle
 from ppb.events import Quit
 from ppb.systems import System
 
@@ -18,7 +18,7 @@ class Failer(System):
         self.run_time = run_time
         self.engine = engine
 
-    def on_heartbeat(self, heartbeat_event: Heartbeat, signal):
+    def on_idle(self, idle_event: Idle, signal):
         if time.monotonic() - self.start > self.run_time:
             raise AssertionError("Test ran too long.")
         if self.fail(self.engine):
@@ -35,7 +35,7 @@ class Quitter(System):
         self.counter = 0
         self.loop_count = loop_count
 
-    def on_heartbeat(self, heartbeat_event: Heartbeat, signal):
+    def on_idle(self, idle_event: Idle, signal):
         self.counter += 1
         if self.counter >= self.loop_count:
             signal(Quit())

--- a/ppb/testutils.py
+++ b/ppb/testutils.py
@@ -2,6 +2,7 @@ import time
 from typing import Callable
 
 from ppb.engine import GameEngine
+from ppb.events import Heartbeat
 from ppb.events import Quit
 from ppb.systems import System
 
@@ -9,17 +10,18 @@ from ppb.systems import System
 class Failer(System):
 
     def __init__(self, *, fail: Callable[[GameEngine], bool], message: str,
-                 run_time: float=1, **kwargs):
+                 run_time: float=1, engine, **kwargs):
         super().__init__(**kwargs)
         self.fail = fail
         self.message = message
         self.start = time.monotonic()
         self.run_time = run_time
+        self.engine = engine
 
-    def activate(self, engine):
+    def on_heartbeat(self, heartbeat_event: Heartbeat, signal):
         if time.monotonic() - self.start > self.run_time:
             raise AssertionError("Test ran too long.")
-        if self.fail(engine):
+        if self.fail(self.engine):
             raise AssertionError(self.message)
         return ()
 

--- a/ppb/testutils.py
+++ b/ppb/testutils.py
@@ -23,8 +23,6 @@ class Failer(System):
             raise AssertionError("Test ran too long.")
         if self.fail(self.engine):
             raise AssertionError(self.message)
-        return ()
-
 
 
 class Quitter(System):
@@ -37,7 +35,7 @@ class Quitter(System):
         self.counter = 0
         self.loop_count = loop_count
 
-    def activate(self, engine):
+    def on_heartbeat(self, heartbeat_event: Heartbeat, signal):
         self.counter += 1
         if self.counter >= self.loop_count:
-            yield Quit()
+            signal(Quit())

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -176,8 +176,8 @@ def test_change_scene_event():
     class Tester(System):
         listening = False
 
-# TODO: This is going to break with the new change.
-        def activate(self, engine):
+        def on_heartbeat(self, heartbeat, signal):
+            engine = heartbeat.engine
             if self.listening:
                 assert isinstance(engine.current_scene, SecondScene)
                 assert len(engine.scenes) == 2
@@ -187,6 +187,7 @@ def test_change_scene_event():
             self.listening = True
 
     with GameEngine(FirstScene, systems=[Updater, Tester]) as ge:
+        ge.register(events.Heartbeat, "engine", ge)
         ge.run()
 
     pause_was_run.assert_called()

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -176,8 +176,8 @@ def test_change_scene_event():
     class Tester(System):
         listening = False
 
-        def on_heartbeat(self, heartbeat, signal):
-            engine = heartbeat.engine
+        def on_idle(self, idle: events.Idle, signal):
+            engine = idle.engine
             if self.listening:
                 assert isinstance(engine.current_scene, SecondScene)
                 assert len(engine.scenes) == 2
@@ -187,7 +187,7 @@ def test_change_scene_event():
             self.listening = True
 
     with GameEngine(FirstScene, systems=[Updater, Tester]) as ge:
-        ge.register(events.Heartbeat, "engine", ge)
+        ge.register(events.Idle, "engine", ge)
         ge.run()
 
     pause_was_run.assert_called()
@@ -262,13 +262,13 @@ def test_flush_events():
     assert len(ge.events) == 0
 
 
-def test_heartbeats():
-    """This test confirms that Heartbeats work."""
+def test_idle():
+    """This test confirms that Idle events work."""
     was_called = False
 
     class TestSystem(System):
 
-        def on_heartbeat(self, event: events.Heartbeat, signal):
+        def on_idle(self, event: events.Idle, signal):
             global was_called
             was_called = True
             signal(events.Quit())

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -98,8 +98,9 @@ def test_scene_change_thrashing():
         if parent.count > 0 and engine.current_scene != parent:
             return True
 
-    failer = Failer(fail=fail, message="ParentScene should not be counting while a child exists.")
-    engine = GameEngine(ParentScene, systems=[Updater(time_step=0.001), failer])
+    engine = GameEngine(ParentScene,
+                        systems=[Updater(time_step=0.001), Failer], fail=fail,
+                        message="ParentScene should not be counting while a child exists.")
     engine.run()
 
 
@@ -114,8 +115,8 @@ def test_scene_change_no_new():
         def change(self):
             return super().change()
 
-    failer = Failer(fail=lambda n: False, message="Will only time out.")
-    with GameEngine(Scene, systems=[Updater, failer]) as ge:
+    with GameEngine(Scene, systems=[Updater, Failer], fail=lambda n: False,
+                    message="Will only time out.") as ge:
         ge.run()
 
 
@@ -175,6 +176,7 @@ def test_change_scene_event():
     class Tester(System):
         listening = False
 
+# TODO: This is going to break with the new change.
         def activate(self, engine):
             if self.listening:
                 assert isinstance(engine.current_scene, SecondScene)
@@ -209,7 +211,7 @@ def test_replace_scene_event():
     class TestFailer(Failer):
 
         def __init__(self, engine):
-            super().__init__(fail=self.fail, message="Will not call")
+            super().__init__(fail=self.fail, message="Will not call", engine=engine)
             self.first_scene_ended = False
 
         def on_scene_stopped(self, event, signal):
@@ -240,8 +242,7 @@ def test_stop_scene_event():
             assert event.scene is self
             test_function()
 
-    failer = Failer(fail=lambda x: False, message="Will only time out.")
-    with GameEngine(TestScene, systems=[Updater, failer]) as ge:
+    with GameEngine(TestScene, systems=[Updater, Failer], fail=lambda x: False, message="Will only time out.") as ge:
         ge.run()
 
     test_function.assert_called()
@@ -258,3 +259,18 @@ def test_flush_events():
     ge.flush_events()
 
     assert len(ge.events) == 0
+
+
+def test_heartbeats():
+    """This test confirms that Heartbeats work."""
+    was_called = False
+
+    class TestSystem(System):
+
+        def on_heartbeat(self, event: events.Heartbeat, signal):
+            global was_called
+            was_called = True
+            signal(events.Quit())
+
+    with GameEngine(BaseScene, systems=[TestSystem, Failer], fail=lambda x: False, message="Can only time out.") as ge:
+        ge.run()

--- a/tests/test_testutil.py
+++ b/tests/test_testutil.py
@@ -1,4 +1,5 @@
 from time import monotonic
+from unittest.mock import Mock
 
 from pytest import mark
 from pytest import raises
@@ -11,11 +12,13 @@ from ppb.events import Quit
 @mark.parametrize("loop_count", range(1, 6))
 def test_quitter(loop_count):
     quitter = testutil.Quitter(loop_count=loop_count)
-    for _ in range(loop_count):
-        for e in quitter.activate(None):  # Quitter doesn't need access to the engine, so we can pass None here.
-            if isinstance(e, Quit):
-                return
-    raise AssertionError("Quitter did not raise a quit event.")
+    signal_mock = Mock()
+    for i in range(loop_count):
+        quitter.__event__(Heartbeat(.01), signal_mock)
+    signal_mock.assert_called_once()
+    assert len(signal_mock.call_args[0]) == 1
+    assert len(signal_mock.call_args[1]) == 0
+    assert isinstance(signal_mock.call_args[0][0], Quit)
 
 
 def test_failer_immediate():

--- a/tests/test_testutil.py
+++ b/tests/test_testutil.py
@@ -4,6 +4,7 @@ from pytest import mark
 from pytest import raises
 
 import ppb.testutils as testutil
+from ppb.events import Heartbeat
 from ppb.events import Quit
 
 
@@ -18,20 +19,20 @@ def test_quitter(loop_count):
 
 
 def test_failer_immediate():
-    failer = testutil.Failer(fail=lambda e: True, message="Expected failure.")
+    failer = testutil.Failer(fail=lambda e: True, message="Expected failure.", engine=None)
 
     with raises(AssertionError):
-        failer.activate(None)
+        failer.__event__(Heartbeat(0.0), lambda x: None)
 
 
 def test_failer_timed():
-    failer = testutil.Failer(fail=lambda e: False, message="Should time out", run_time=0.1)
+    failer = testutil.Failer(fail=lambda e: False, message="Should time out", run_time=0.1, engine=None)
 
     start_time = monotonic()
 
     while True:
         try:
-            failer.activate(None)
+            failer.__event__(Heartbeat(0.0), lambda x: None)
         except AssertionError as e:
             if e.args[0] == "Test ran too long.":
                 end_time = monotonic()

--- a/tests/test_testutil.py
+++ b/tests/test_testutil.py
@@ -5,7 +5,7 @@ from pytest import mark
 from pytest import raises
 
 import ppb.testutils as testutil
-from ppb.events import Heartbeat
+from ppb.events import Idle
 from ppb.events import Quit
 
 
@@ -14,7 +14,7 @@ def test_quitter(loop_count):
     quitter = testutil.Quitter(loop_count=loop_count)
     signal_mock = Mock()
     for i in range(loop_count):
-        quitter.__event__(Heartbeat(.01), signal_mock)
+        quitter.__event__(Idle(.01), signal_mock)
     signal_mock.assert_called_once()
     assert len(signal_mock.call_args[0]) == 1
     assert len(signal_mock.call_args[1]) == 0
@@ -25,7 +25,7 @@ def test_failer_immediate():
     failer = testutil.Failer(fail=lambda e: True, message="Expected failure.", engine=None)
 
     with raises(AssertionError):
-        failer.__event__(Heartbeat(0.0), lambda x: None)
+        failer.__event__(Idle(0.0), lambda x: None)
 
 
 def test_failer_timed():
@@ -35,7 +35,7 @@ def test_failer_timed():
 
     while True:
         try:
-            failer.__event__(Heartbeat(0.0), lambda x: None)
+            failer.__event__(Idle(0.0), lambda x: None)
         except AssertionError as e:
             if e.args[0] == "Test ran too long.":
                 end_time = monotonic()


### PR DESCRIPTION
So, doing what I discussed in the slack: Removing activate, adding a heartbeat event.

Need to decide if we heartbeat between each publish, or we clear the queue between each heartbeat.

If we do the former, we're going to start seeing scheduling silliness, but that just comes from asynchronous design.

If we do the latter, it's easier to make events happen in a sequence, but still going to have some of the asynchronous silliness because, well, we're technically async.

- [x] Add heartbeat, switch the test utilities to use a heartbeat system.
- [x] Remove activate, switch remaining systems to use heartbeat system.
- [x] Clean up the main loop to reduce the processing time of the busy loop.