### PR TITLE
Bors: Delete branches from the PPB repository once merged

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -7,3 +7,5 @@ status = [
   "macOS PYTHON:3.6.8",
   "macOS PYTHON:3.7.2",
 ]
+
+delete_merged_branches = true


### PR DESCRIPTION
From [the documentation]:

> If set to true, and if the PR branch is on the same repository that bors-ng itself is on, the branch will be deleted.

[the documentation]: https://bors.tech/documentation/#configuration-borstoml