### PR TITLE
CI: Hardcode pip requirements into the Dockerfiles

### DIFF
--- a/.ci/dockerfiles/docs
+++ b/.ci/dockerfiles/docs
@@ -4,7 +4,6 @@ RUN apt update || true && \
     apt install -qq -y make && \
     rm -rf /var/cache/apt/*
 
-ADD requirements-docs.txt requirements.txt /
-RUN python3 -m pip install --upgrade-strategy eager -U -r requirements-docs.txt && \
-    python3 -m pip install --upgrade-strategy eager -U -r requirements.txt && \
+RUN python3 -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' && \
+    python3 -m pip install --upgrade-strategy eager -U 'sphinx' 'sphinx_rtd_theme' && \
     rm -rf ~/.cache/pip

--- a/.ci/dockerfiles/generate.sh
+++ b/.ci/dockerfiles/generate.sh
@@ -31,8 +31,12 @@ function template() {
     preinstall="$1"; shift
     PIP="$(py $image) -m pip install --upgrade-strategy eager -U"
     CMDS=()
-    for requirement in "$@" requirements.txt; do
-        CMDS+=("$PIP -r $requirement")
+    for requirement in requirements.txt "$@"; do
+        REQS=()
+        while read req; do
+            REQS+=("'$req'")
+        done < ../../${requirement}
+        CMDS+=("$PIP ${REQS[*]}")
     done
     CMDS+=("$(postinstall $image)")
 
@@ -41,7 +45,6 @@ FROM ${image}
 
 ${preinstall}
 
-ADD $@ requirements.txt /
 $(run $image "${CMDS[@]}")
 EOF
 }

--- a/.ci/dockerfiles/pypy_3.6-slim
+++ b/.ci/dockerfiles/pypy_3.6-slim
@@ -4,7 +4,6 @@ RUN apt update || true && \
     apt install -qq -y pkgconf libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev gcc && \
     rm -rf /var/cache/apt/*
 
-ADD requirements-tests.txt requirements.txt /
-RUN pypy3 -m pip install --upgrade-strategy eager -U -r requirements-tests.txt && \
-    pypy3 -m pip install --upgrade-strategy eager -U -r requirements.txt && \
+RUN pypy3 -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' && \
+    pypy3 -m pip install --upgrade-strategy eager -U 'pytest' && \
     rm -rf ~/.cache/pip

--- a/.ci/dockerfiles/python_3.6-slim
+++ b/.ci/dockerfiles/python_3.6-slim
@@ -2,7 +2,6 @@ FROM python:3.6-slim
 
 
 
-ADD requirements-tests.txt requirements.txt /
-RUN python3 -m pip install --upgrade-strategy eager -U -r requirements-tests.txt && \
-    python3 -m pip install --upgrade-strategy eager -U -r requirements.txt && \
+RUN python3 -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' && \
+    python3 -m pip install --upgrade-strategy eager -U 'pytest' && \
     rm -rf ~/.cache/pip

--- a/.ci/dockerfiles/python_3.6-windowsservercore-1809
+++ b/.ci/dockerfiles/python_3.6-windowsservercore-1809
@@ -2,7 +2,6 @@ FROM python:3.6-windowsservercore-1809
 
 
 
-ADD requirements-tests.txt requirements.txt /
-RUN ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U -r requirements-tests.txt ) -and \
-    ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U -r requirements.txt ) -and \
+RUN ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' ) -and \
+    ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U 'pytest' ) -and \
     ( Remove-Item –path %LOCALAPPDATA%\pip\Cache -recurse -ErrorAction Ignore )

--- a/.ci/dockerfiles/python_3.7-slim
+++ b/.ci/dockerfiles/python_3.7-slim
@@ -2,7 +2,6 @@ FROM python:3.7-slim
 
 
 
-ADD requirements-tests.txt requirements.txt /
-RUN python3 -m pip install --upgrade-strategy eager -U -r requirements-tests.txt && \
-    python3 -m pip install --upgrade-strategy eager -U -r requirements.txt && \
+RUN python3 -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' && \
+    python3 -m pip install --upgrade-strategy eager -U 'pytest' && \
     rm -rf ~/.cache/pip

--- a/.ci/dockerfiles/python_3.7-windowsservercore-1809
+++ b/.ci/dockerfiles/python_3.7-windowsservercore-1809
@@ -2,7 +2,6 @@ FROM python:3.7-windowsservercore-1809
 
 
 
-ADD requirements-tests.txt requirements.txt /
-RUN ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U -r requirements-tests.txt ) -and \
-    ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U -r requirements.txt ) -and \
+RUN ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' ) -and \
+    ( C:\Python\python.exe -m pip install --upgrade-strategy eager -U 'pytest' ) -and \
     ( Remove-Item –path %LOCALAPPDATA%\pip\Cache -recurse -ErrorAction Ignore )

--- a/.ci/dockerfiles/python_3.8-rc-slim
+++ b/.ci/dockerfiles/python_3.8-rc-slim
@@ -4,7 +4,6 @@ RUN apt update || true && \
     apt install -qq -y pkgconf libsdl-image1.2-dev libsdl-mixer1.2-dev libsdl-ttf2.0-dev libsdl1.2-dev libsmpeg-dev libportmidi-dev libswscale-dev libavformat-dev libavcodec-dev libfreetype6-dev gcc && \
     rm -rf /var/cache/apt/*
 
-ADD requirements-tests.txt requirements.txt /
-RUN python3 -m pip install --upgrade-strategy eager -U -r requirements-tests.txt && \
-    python3 -m pip install --upgrade-strategy eager -U -r requirements.txt && \
+RUN python3 -m pip install --upgrade-strategy eager -U 'pygame' 'ppb-vector' 'dataclasses; python_version < "3.7"' && \
+    python3 -m pip install --upgrade-strategy eager -U 'pytest' && \
     rm -rf ~/.cache/pip


### PR DESCRIPTION
Pro: Works around an issue with the way Cirrus caches containers: cirruslabs/cirrus-ci-docs#273

Cons:
- Requires regenerating/recommiting Dockerfiles whenever requirements change.
- This will break if the character `'` (rather than `"`) is used in a requirements file.

Marked as part of project [vector-1.0](https://github.com/orgs/ppb/projects/6) as it is blocking for #204.