### PR TITLE
GameObjectCollection.add: Behave correctly with inheritance

### DIFF
--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -48,7 +48,9 @@ class GameObjectCollection(Collection):
         if isinstance(tags, (str, bytes)):
             raise TypeError("You passed a string instead of an iterable, this probably isn't what you intended.\n\nTry making it a tuple.")
         self.all.add(game_object)
-        self.kinds[type(game_object)].add(game_object)
+
+        for kind in type(game_object).mro():
+            self.kinds[kind].add(game_object)
         for tag in tags:
             self.tags[tag].add(game_object)
 

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -93,7 +93,8 @@ class GameObjectCollection(Collection):
             container.remove(myObject)
         """
         self.all.remove(game_object)
-        self.kinds[type(game_object)].remove(game_object)
+        for kind in type(game_object).mro():
+            self.kinds[kind].remove(game_object)
         for s in self.tags.values():
             s.discard(game_object)
 

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -124,6 +124,14 @@ class BaseScene(Scene, EventMixin):
         return (x for x in self.game_objects)
 
     @property
+    def kinds(self):
+        return self.game_objects.kinds
+
+    @property
+    def tags(self):
+        return self.game_objects.tags
+
+    @property
     def main_camera(self) -> Camera:
         return next(self.game_objects.get(tag="main_camera"))
 

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -102,8 +102,11 @@ def test_remove_methods(container, player, enemies):
     container.remove(player)
 
     assert player not in container
-    assert player not in container.get(kind=TestPlayer)
-    assert player not in container.get(tag="test")
+    for kind in container.kinds:
+        assert player not in container.get(kind=kind)
+    for tag in container.tags:
+        assert player not in container.get(tag=tag)
+
     assert enemies[0] in container
     assert enemies[0] in container.get(tag="test")
     assert enemies[1] in container

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -71,30 +71,13 @@ def test_get_methods(container, player, enemies):
     container.add(enemies[1], ["red"])
     container.add(sprite)
 
-    enemy_set = set(container.get(kind=TestEnemy))
-    assert len(enemy_set) == 2
-    for enemy in enemies:
-        assert enemy in enemy_set
+    assert set(container.get(kind=TestEnemy)) == set(enemies)
+    assert set(container.get(kind=TestPlayer)) == {player}
+    assert set(container.get(kind=TestSprite)) == {sprite}
 
-    player_set = set(container.get(kind=TestPlayer))
-    assert len(player_set) == 1
-    assert player in player_set
+    assert set(container.get(tag="red")) == {player, enemies[1]}
 
-    sprite_set = set(container.get(kind=TestSprite))
-    assert len(sprite_set) == 1
-    assert sprite in sprite_set
-
-    red_set = set(container.get(tag="red"))
-    assert len(red_set) == 2
-    assert player in red_set
-    assert enemies[1] in red_set
-    assert enemies[0] not in red_set
-
-    null_set = set(container.get(tag="this doesn't exist"))
-    assert len(null_set) == 0
-    assert player not in null_set
-    assert enemies[0] not in null_set
-    assert enemies[1] not in null_set
+    assert set(container.get(tag="this doesn't exist")) == set()
 
     with raises(TypeError):
         container.get()

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -17,6 +17,10 @@ class TestPlayer:
     pass
 
 
+class TestSubclassPlayer(TestPlayer):
+    pass
+
+
 class TestSprite:
     pass
 
@@ -26,9 +30,15 @@ def containers():
     yield BaseScene(Mock())
 
 
-@fixture()
-def player():
-    return TestPlayer()
+def players():
+    yield TestPlayer()
+    yield TestSubclassPlayer()
+
+
+def players_and_containers():
+    for player in players():
+        for container in containers():
+            yield player, container
 
 
 @fixture()
@@ -42,7 +52,7 @@ def scene():
     return BaseScene(engine)
 
 
-@mark.parametrize("container", containers())
+@mark.parametrize("player, container", players_and_containers())
 def test_add_methods(container, player, enemies):
     container.add(player)
     for group, sprite in zip(("red", "blue"), enemies):
@@ -52,7 +62,7 @@ def test_add_methods(container, player, enemies):
         assert enemy in container
 
 
-@mark.parametrize("container", containers())
+@mark.parametrize("player, container", players_and_containers())
 def test_get_methods(container, player, enemies):
 
     sprite = TestSprite()
@@ -90,14 +100,14 @@ def test_get_methods(container, player, enemies):
         container.get()
 
 
-@mark.parametrize("container", containers())
+@mark.parametrize("player, container", players_and_containers())
 def test_get_with_string_tags(container, player):
     """Test that addings a string instead of an array-like throws."""
     with raises(TypeError):
         container.add(player, "player")
 
 
-@mark.parametrize("container", containers())
+@mark.parametrize("player, container", players_and_containers())
 def test_remove_methods(container, player, enemies):
     container.add(player, ["test"])
     container.add(enemies[0], ["test"])
@@ -116,8 +126,9 @@ def test_remove_methods(container, player, enemies):
     assert enemies[1] in container
 
 
-@mark.parametrize("container", [GameObjectCollection()])
-def test_collection_methods(container, player, enemies):
+@mark.parametrize("player", players())
+def test_collection_methods(player, enemies):
+    container = GameObjectCollection()
     container.add(player)
     container.add(enemies[0])
 


### PR DESCRIPTION
- [x] Make scene tests also use a subclass of `TestPlayer`.
  This shows that `scene.get(kind=TestPlayer)` misses (instances of) subclasses.
- [x] Fix the behaviour in `GameObjectCollection`.
  Done by adding to all kinds in the MRO.  Possibly not the most efficient solution.
- [x] Refactor `tests/scenes/get_methods`.