### PR TITLE
Fix Resource Paths in REPL

### DIFF
--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -1,8 +1,5 @@
 from inspect import getfile
-from numbers import Number
-from os.path import realpath
 from pathlib import Path
-from typing import Dict, Iterable, Sequence
 from typing import Union
 
 from ppb import Vector
@@ -296,5 +293,8 @@ class BaseSprite(EventMixin, Rotatable):
 
     def __resource_path__(self):
         if self.resource_path is None:
-            self.resource_path = Path(realpath(getfile(type(self)))).absolute().parent
+            if type(self).__module__ == '__main__':
+                self.resource_path = Path.cwd().resolve()
+            else:
+                self.resource_path = Path(getfile(type(self))).resolve().parent
         return self.resource_path

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -325,3 +325,14 @@ def test_rotatable_base_sprite():
 
     test_sprite.rotate(1)
     assert test_sprite.rotation == 1
+
+
+def test_sprite_in_main():
+    class TestSprite(BaseSprite):
+        pass
+
+    TestSprite.__module__ = '__main__'
+
+    s = TestSprite()
+
+    assert s.__resource_path__()  # We don't care what it is, as long as it's something


### PR DESCRIPTION
Fix the crashing bug when running PPB in a REPL by using the CWD when the module is `__main__`.

Closes #267.