### PR TITLE
FauxFloat: Redo operations to allow for double-fauxs to work

### DIFF
--- a/ppb/utils.py
+++ b/ppb/utils.py
@@ -62,76 +62,73 @@ class FauxFloat(numbers.Real):
     """
 
     def __abs__(self):
-        return float(self).__abs__()
+        return abs(float(self))
 
     def __add__(self, other):
-        return float(self).__add__(other)
+        return float(self) + other
 
     def __ceil__(self):
         return math.ceil(float(self))
 
     def __eq__(self, other):
-        return float(self).__eq__(other)
-
-    def __float__(self, other):
-        return float(self).__float__(other)
+        return float(self) == other
 
     def __floor__(self):
         return math.floor(float(self))
 
     def __floordiv__(self, other):
-        return float(self).__floordiv__(other)
+        return float(self) // other
 
     def __ge__(self, other):
-        return float(self).__ge__(other)
+        return float(self) >= other
 
     def __gt__(self, other):
-        return float(self).__gt__(other)
+        return float(self) > other
 
     def __le__(self, other):
-        return float(self).__le__(other)
+        return float(self) <= other
 
     def __lt__(self, other):
-        return float(self).__lt__(other)
+        return float(self) < other
 
     def __mod__(self, other):
-        return float(self).__mod__(other)
+        return float(self) % other
 
     def __mul__(self, other):
-        return float(self).__mul__(other)
+        return float(self) * other
 
     def __neg__(self):
-        return float(self).__neg__()
+        return -float(self)
 
     def __pos__(self):
-        return float(self).__pos__()
+        return +float(self)
 
     def __pow__(self, other):
-        return float(self).__pow__(other)
+        return float(self) ** other
 
     def __radd__(self, other):
-        return float(self).__radd__(other)
+        return other + float(self)
 
     def __rfloordiv__(self, other):
-        return float(self).__rfloordiv__(other)
+        return other // float(self)
 
     def __rmod__(self, other):
-        return float(self).__rmod__(other)
+        return other % float(self)
 
     def __rmul__(self, other):
-        return float(self).__rmul__(other)
+        return other * float(self)
 
     def __round__(self, ndigits=None):
-        return float(self).__round__(ndigits)
+        return round(float(self), ndigits)
 
     def __rpow__(self, other):
-        return float(self).__rpow__(other)
+        return other ** float(self)
 
     def __rtruediv__(self, other):
-        return float(self).__rtruediv__(other)
+        return other / float(self)
 
     def __truediv__(self, other):
-        return float(self).__truediv__(other)
+        return float(self) / other
 
     def __trunc__(self):
-        return float(self).__trunc__()
+        return math.trunc(float(self))

--- a/tests/test_fauxfloat.py
+++ b/tests/test_fauxfloat.py
@@ -45,11 +45,30 @@ def test_unary_ops(operation, num):
     num=st.floats(allow_nan=False, allow_infinity=False),
     other=st.floats(allow_nan=False, allow_infinity=False),
 )
-def test_binary_ops(operation, num, other):
+def test_binary_ops_float(operation, num, other):
     t = get_thingy(num)
 
     assert operation(t, other) == operation(num, other)
     assert operation(other, t) == operation(other, num)
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        operator.lt, operator.le, operator.eq, operator.ne, operator.ge,
+        operator.gt, operator.add, operator.mul, operator.sub,
+    ],
+)
+@given(
+    num=st.floats(allow_nan=False, allow_infinity=False),
+    other=st.floats(allow_nan=False, allow_infinity=False),
+)
+def test_binary_ops_thingy(operation, num, other):
+    t = get_thingy(num)
+    o = get_thingy(other)
+
+    assert operation(t, o) == operation(num, o)
+    assert operation(o, t) == operation(o, num)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Found that things like `min(s.left for s in scene.sprites)` didn't work.

Fixed that.