### PR TITLE
Improve tests/fauxfloat

### DIFF
--- a/tests/test_fauxfloat.py
+++ b/tests/test_fauxfloat.py
@@ -26,11 +26,11 @@ class RealFauxFloat(FauxFloat):
 
 
 @pytest.mark.parametrize(
-    "operation",
-    [
+    "operation", [
         float, abs, bool, int, math.ceil, math.floor, math.trunc, operator.neg,
         operator.pos,
     ],
+    ids=lambda op: op.__name__,
 )
 @given(num=st.floats(allow_nan=False, allow_infinity=False))
 def test_unary_ops(operation, num: float):
@@ -47,6 +47,7 @@ NON_ZERO_OPS = [
         operator.lt, operator.le, operator.eq, operator.ne, operator.ge,
         operator.gt, operator.add, operator.mul, operator.sub,
     ] + NON_ZERO_OPS,
+    ids=lambda op: op.__name__,
 )
 @pytest.mark.parametrize(
     "num_type, other_type", [

--- a/tests/test_fauxfloat.py
+++ b/tests/test_fauxfloat.py
@@ -22,9 +22,11 @@ class RealFauxFloat(FauxFloat):
 
 
 
-# The use of parametrize() over st.sampled_from() is deliberate.
-
-
+# The use of pytest.mark.parametrize is prefered to st.sampled_from for
+# operators and datatypes for 2 reasons:
+# - It guarantees the parameter space is explored exhaustively.
+# - It instantiates multiple tests, whose names encode the parameters, such as
+#   test_binary_ops[RealFauxFloat-float-lt]
 @pytest.mark.parametrize(
     "operation", [
         float, abs, bool, int, math.ceil, math.floor, math.trunc, operator.neg,

--- a/tests/test_fauxfloat.py
+++ b/tests/test_fauxfloat.py
@@ -37,39 +37,26 @@ def test_unary_ops(operation, num: float):
     assert operation(RealFauxFloat(num)) == operation(num)
 
 
+NON_ZERO_OPS = [
+    operator.floordiv, operator.mod, operator.truediv,
+]
+
+
 @pytest.mark.parametrize(
-    "operation",
-    [
+    "operation", [
         operator.lt, operator.le, operator.eq, operator.ne, operator.ge,
         operator.gt, operator.add, operator.mul, operator.sub,
-    ],
+    ] + NON_ZERO_OPS,
 )
 @given(
     num=st.floats(allow_nan=False, allow_infinity=False),
     other=st.floats(allow_nan=False, allow_infinity=False),
 )
 def test_binary_ops(operation, num, other):
+    if(operation in NON_ZERO_OPS):
+        assume(num != 0 and other != 0)
+
     t = RealFauxFloat(num)
-
-    assert operation(t, other) == operation(num, other)
-    assert operation(other, t) == operation(other, num)
-
-
-@pytest.mark.parametrize(
-    "operation",
-    [
-        operator.floordiv, operator.mod, operator.truediv,
-    ],
-)
-@given(
-    num=st.floats(allow_nan=False, allow_infinity=False),
-    other=st.floats(allow_nan=False, allow_infinity=False),
-)
-def test_binary_ops_nonzero(operation, num, other):
-    assume(num != 0)
-    assume(other != 0)
-    t = RealFauxFloat(num)
-
     assert operation(t, other) == operation(num, other)
     assert operation(other, t) == operation(other, num)
 

--- a/tests/test_fauxfloat.py
+++ b/tests/test_fauxfloat.py
@@ -50,20 +50,20 @@ NON_ZERO_OPS = [
     ids=lambda op: op.__name__,
 )
 @pytest.mark.parametrize(
-    "num_type, other_type", [
+    "left_type, right_type", [
         (RealFauxFloat, float), (float, RealFauxFloat),
         (RealFauxFloat, RealFauxFloat),
     ],
 )
 @given(
-    num=st.floats(allow_nan=False, allow_infinity=False),
-    other=st.floats(allow_nan=False, allow_infinity=False),
+    left=st.floats(allow_nan=False, allow_infinity=False),
+    right=st.floats(allow_nan=False, allow_infinity=False),
 )
-def test_binary_ops(operation, num, num_type, other, other_type):
+def test_binary_ops(operation, left, left_type, right, right_type):
     if(operation in NON_ZERO_OPS):
-        assume(other != 0)
+        assume(right != 0)
 
-    assert operation(num_type(num), other_type(other)) == operation(num, other)
+    assert operation(left_type(left), right_type(right)) == operation(left, right)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_fauxfloat.py
+++ b/tests/test_fauxfloat.py
@@ -48,28 +48,37 @@ NON_ZERO_OPS = [
         operator.gt, operator.add, operator.mul, operator.sub,
     ] + NON_ZERO_OPS,
 )
+@pytest.mark.parametrize(
+    "num_type, other_type", [
+        (RealFauxFloat, float), (float, RealFauxFloat),
+        (RealFauxFloat, RealFauxFloat),
+    ],
+)
 @given(
     num=st.floats(allow_nan=False, allow_infinity=False),
     other=st.floats(allow_nan=False, allow_infinity=False),
 )
-def test_binary_ops(operation, num, other):
+def test_binary_ops(operation, num, num_type, other, other_type):
     if(operation in NON_ZERO_OPS):
-        assume(num != 0 and other != 0)
+        assume(other != 0)
 
-    t = RealFauxFloat(num)
-    assert operation(t, other) == operation(num, other)
-    assert operation(other, t) == operation(other, num)
+    assert operation(num_type(num), other_type(other)) == operation(num, other)
 
 
+@pytest.mark.parametrize(
+    "base_type, exponent_type", [
+        (RealFauxFloat, float), (float, RealFauxFloat),
+        (RealFauxFloat, RealFauxFloat),
+    ],
+)
 @given(
     base=st.floats(allow_nan=False, allow_infinity=False, min_value=-1e20, max_value=1e20),
     exponent=st.floats(allow_nan=False, allow_infinity=False, min_value=-10, max_value=10),
 )
-def test_pow(base, exponent):
+def test_pow(base, base_type, exponent, exponent_type):
     assume(base != 0 and exponent != 0)
 
-    assert operator.pow(RealFauxFloat(base), exponent) == operator.pow(base, exponent)
-    assert operator.pow(base, RealFauxFloat(exponent)) == operator.pow(base, exponent)
+    assert operator.pow(base_type(base), exponent_type(exponent)) == operator.pow(base, exponent)
 
 
 @given(


### PR DESCRIPTION
- [x] Systematically test all combinations of `float` and `FauxFloats` with binary operators.
  This catches the bug fixed in #279.
- Readability improvements
  - [x] Replace `Thingy`/`get_thingy` with something more obvious.
  - [x] Refactor away `test_binary_ops_nonzero`.
  - [x] Display useful names in operators, when parameterizing tests.