### PR TITLE
[nomerge] Nix __resource_path__

### DIFF
--- a/examples/animated_sprite.py
+++ b/examples/animated_sprite.py
@@ -6,7 +6,7 @@ import ppb.events as events
 
 
 class Blob(ppb.BaseSprite):
-    image = Animation("./resources/blob_{0..6}.png", 10)
+    image = Animation("resources/blob_{0..6}.png", 10)
     target = ppb.Vector(0, 0)
     speed = 1
 
@@ -15,8 +15,9 @@ class Blob(ppb.BaseSprite):
 
     def on_update(self, event: events.Update, signal):
         intent_vector = self.target - self.position
-        self.position += intent_vector.scale(self.speed * event.time_delta)
-        self.rotation = math.degrees(math.atan2(intent_vector.y, intent_vector.x)) - 90
+        if intent_vector:
+            self.position += intent_vector.scale(self.speed * event.time_delta)
+            self.rotation = math.degrees(math.atan2(intent_vector.y, intent_vector.x)) - 90
 
 
 def setup(scene):

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -260,12 +260,3 @@ class BaseSprite(EventMixin, Rotatable):
         if self.image is None:
             self.image = f"{type(self).__name__.lower()}.png"
         return self.image
-
-    def __resource_path__(self):
-        if self.resource_path is None:
-            try:
-                file_path = Path(getfile(type(self))).resolve().parent
-            except TypeError:
-                file_path = Path.cwd().resolve()
-            self.resource_path = file_path
-        return self.resource_path

--- a/ppb/vfs.py
+++ b/ppb/vfs.py
@@ -1,0 +1,60 @@
+"""
+Handles opening files from the Python "VFS".
+"""
+try:
+    import importlib.resources as impres
+except ImportError:
+    # Backport
+    import importlib_resources as impres
+
+
+def _splitpath(filepath):
+    if '/' in filepath:
+        slashed, filename = filepath.rsplit('/', 1)
+        modulename = slashed.replace('/', '.')
+    else:
+        modulename = '__main__'
+        filename = filepath
+
+    return modulename, filename
+
+
+def open(filepath, *, encoding=None, errors='strict'):
+    """
+    Opens the given file, whose name is resolved with the import machinery.
+
+    If you want a text file, pass an encoding argument.
+
+    Returns the open file and the base filename (suitable for filename-based type hinting).
+    """
+    modulename, filename = _splitpath(filepath)
+
+    if encoding is None:
+        return impres.open_binary(modulename, filename), filename
+    else:
+        return impres.open_text(modulename, filename, encoding, errors), filename
+
+
+def exists(filepath):
+    """
+    Checks if the given resource exists and is a resources.
+    """
+    modulename, filename = _splitpath(filepath)
+    return impres.is_resource(modulename, filepath)
+
+
+def iterdir(modulepath):
+    modname = modulepath.replace('/', '.')
+    yield from impres.contents(modname)
+
+
+def walk(modulepath):
+    """
+    Generates all the resources in the given package.
+    """
+    for name in iterdir(modulepath):
+        fullname = f"{modulepath}/{name}"
+        if exists(fullname):
+            yield fullname
+        else:
+            yield from walk(fullname)

--- a/ppb/vfs.py
+++ b/ppb/vfs.py
@@ -93,5 +93,5 @@ def walk(modulepath):
         if exists(fullname):
             yield fullname
         elif modulepath != '__main__':
-            # Don't recurse from __main__, they should just be regular packages
+            # Don't recurse from __main__, that would be all installed packages.
             yield from walk(fullname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pygame
 ppb-vector ~= 1.0a2
 dataclasses; python_version < "3.7"
+importlib_resources; python_version < "3.7"

--- a/tests/test_sprites.py
+++ b/tests/test_sprites.py
@@ -326,18 +326,3 @@ def test_rotatable_base_sprite():
 
     test_sprite.rotate(1)
     assert test_sprite.rotation == 1
-
-
-def test_sprite_in_main():
-    """
-    Test that Sprite.__resource_path__ returns a meaningful value inside
-    REPLs where __main__ doesn't have a file.
-    """
-    class TestSprite(BaseSprite):
-        pass
-
-    s = TestSprite()
-
-    with patch("ppb.sprites.getfile", side_effect=TypeError):
-        # This patch simulates what happens when TestSprite was defined in the REPL
-        assert s.__resource_path__()  # We don't care what it is, as long as it's something


### PR DESCRIPTION
This just removes `__resource_path__` and makes all resources resolution relative to the Python module "virtual filesystem".

Note that this requires an `__init__.py` to exist next to any resource files.