### PR TITLE
Limit Python versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pygame
+pygame < 2
 ppb-vector ~= 1.0a2
 dataclasses; python_version < "3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,4 +33,4 @@ packages =
 setup_requires =
     pytest-runner
 
-python_requires = >= 3.6
+python_requires = >= 3.6, < 3.8


### PR DESCRIPTION
Don't allow Python 3.8.

This is preemptive because PyGame 1.9 is currently not planned to be compatible with 3.8, and while both Python 3.8 and PyGame 2 are a ways off, we want to prevent accidental incompatibilities the best we can.