### PR TITLE
Bump version number to v0.6.0b1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ test = pytest
 
 [metadata]
 name = ppb
-version = 0.5.0
+version = 0.6.0b1
 author = Piper Thunstrom
 author_email = pathunstrom@gmail.com
 description = An Event Driven Python Game Engine


### PR DESCRIPTION
We don't need an alpha on this release, it's gotten a lot of wheel
kicking already. We do want to be able to run tests for both ppb-vector
and ppb so we need a beta release.