### PR TITLE
Don't run Python 3.8 in Cirrus.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ task:
     matrix:
       - IMAGE: python:3.6-slim
       - IMAGE: python:3.7-slim
-      - IMAGE: python:3.8-rc-slim
+      # - IMAGE: python:3.8-rc-slim
       - IMAGE: pypy:3.6-slim
 
   container:


### PR DESCRIPTION
PPB explicitly disallows installing on 3.8