### PR TITLE
Enable passing arbitrary options to the engine through the standard launchers

### DIFF
--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -27,7 +27,7 @@ def _make_kwargs(setup, title, engine_opts):
 
 
 def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
-        starting_scene=BaseScene, title="PursuedPyBear"):
+        starting_scene=BaseScene, title="PursuedPyBear", **engine_opts):
     """
     Run a small game.
 
@@ -42,7 +42,7 @@ def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
     """
     logging.basicConfig(level=log_level)
 
-    with GameEngine(starting_scene, **_make_kwargs(setup, title)) as eng:
+    with make_engine(setup, starting_scene=starting_scene, title=title, **engine_opts) as eng:
         eng.run()
 
 

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -14,18 +14,19 @@ __all__ = (
 )
 
 
-def _make_kwargs(setup, title):
+def _make_kwargs(setup, title, engine_opts):
     kwargs = {
         "resolution": (800, 600),
         "scene_kwargs": {
             "set_up": setup,
         },
         "window_title": title,
-
+        **engine_opts
     }
     return kwargs
 
-def run(setup: Callable[[BaseScene], None]=None, *, log_level=logging.WARNING,
+
+def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
         starting_scene=BaseScene, title="PursuedPyBear"):
     """
     Run a small game.
@@ -45,6 +46,7 @@ def run(setup: Callable[[BaseScene], None]=None, *, log_level=logging.WARNING,
         eng.run()
 
 
-def make_engine(setup: Callable[[BaseScene], None]=None, *,
-                starting_scene=BaseScene, title="PursedPyBear"):
-    return GameEngine(starting_scene, **_make_kwargs(setup, title))
+def make_engine(setup: Callable[[BaseScene], None] = None, *,
+                starting_scene=BaseScene, title="PursedPyBear",
+                **engine_opts):
+    return GameEngine(starting_scene, **_make_kwargs(setup, title, engine_opts))


### PR DESCRIPTION
Punishing users for wanting to use features isn't a great look.

This allows users to use the standard startup functions with arbitrary options (like `systems`).