### PR TITLE
Sprite Layer API

### DIFF
--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -185,5 +185,16 @@ class BaseScene(EventMixin):
         """
         self.game_objects.remove(game_object)
 
-    def sprite_layers(self):
+    def sprite_layers(self) -> Iterator:
+        """
+        Return an iterator of the contained Sprites in ascending layer
+        order.
+
+        Sprites are part of a layer if they have a layer attribute equal to
+        that layer value. Sprites without a layer attribute are considered
+        layer 0.
+
+        This function exists primarily to assist the Renderer subsystem,
+        but will be left public for other creative uses.
+        """
         return sorted(self, key=lambda s: getattr(s, "layer", 0))

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -184,3 +184,6 @@ class BaseScene(EventMixin):
             scene.remove(my_game_object)
         """
         self.game_objects.remove(game_object)
+
+    def sprite_layers(self):
+        return sorted(self, key=lambda s: getattr(s, "layer", 0))

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -216,6 +216,8 @@ class BaseSprite(EventMixin, Rotatable):
     position: Vector = Vector(0, 0)
     #: The width/height of the sprite (sprites are square)
     size: Union[int, float] = 1
+    #: The layer a sprite exists on.
+    layer: int = 0
 
     def __init__(self, **kwargs):
         super().__init__()

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -172,7 +172,7 @@ def test_default_layer_named():
             "something_else": 2,
             "another": 3
         }
-        _default_layer = "our_default"
+        default_layer = "our_default"
 
     scene = LayeredScene()
 
@@ -186,9 +186,9 @@ def test_default_layer_set_layer():
 
     class LayeredScene(scenes.BaseScene):
         named_layers = ["background", "mobs", "particles"]
-        _default_layer = "particles"
+        default_layer = "particles"
 
     scene = LayeredScene()
 
     scene.default_layer = "mobs"
-    assert scene.default_layer == 1
+    assert scene.default_layer == "particles"

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -40,11 +40,11 @@ def test_change_layer():
     for sprite in ones:
         scene.add(sprite)
 
-    assert list(scene.sprite_layers())[0] == test_sprite
+    assert list(scene.sprite_layers())[0] is test_sprite
 
     test_sprite.layer = 2
 
-    assert list(scene.sprite_layers())[-1] == test_sprite
+    assert list(scene.sprite_layers())[-1] is test_sprite
 
 
 def test_layering_without_layer_attribute():
@@ -56,4 +56,4 @@ def test_layering_without_layer_attribute():
     for x in range(1, 6):
         scene.add(LayeredSprite(x))
 
-    assert list(scene.sprite_layers())[0] == test_sprite
+    assert list(scene.sprite_layers())[0] is test_sprite

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -8,10 +8,11 @@ class LayeredSprite:
         self.layer = layer
 
 
-class NoLayer: pass
+class NoLayer:
+    pass
 
 
-def test_layering_attribute():
+def test_layering_attribute_ints():
 
     class LayeredScene(scenes.BaseScene):
 
@@ -21,7 +22,7 @@ def test_layering_attribute():
                 self.add(LayeredSprite(x))
 
     scene = LayeredScene()
-    for lower_sprite, higher_sprite in zip(scene, list(scene)[1:]):
+    for lower_sprite, higher_sprite in zip(scene.sprites(), list(scene.sprites())[1:]):
         if isinstance(lower_sprite, camera.Camera) or isinstance(higher_sprite, camera.Camera):
             continue
         assert lower_sprite.layer < higher_sprite.layer

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -20,7 +20,7 @@ def test_layering_attribute():
 
         def __init__(self):
             super().__init__()
-            for x in range(5):
+            for x in range(-3, 3):
                 self.add(LayeredSprite(x))
 
     scene = LayeredScene()
@@ -57,18 +57,3 @@ def test_layering_without_layer_attribute():
         scene.add(LayeredSprite(x))
 
     assert list(scene.sprite_layers())[0] == test_sprite
-
-
-def test_set_default_layer():
-
-    class DefaultLayer(scenes.BaseScene):
-        default_layer = 3
-
-    scene = DefaultLayer()
-
-    scene.add(LayeredSprite(layer=1))
-    scene.add(LayeredSprite(layer=5))
-    test_sprite = NoLayer()
-    scene.add(test_sprite)
-
-    assert list(scene.sprite_layers)[1] is test_sprite

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,3 +1,5 @@
+from itertools import islice
+
 import ppb.camera as camera
 import ppb.scenes as scenes
 
@@ -22,7 +24,7 @@ def test_layering_attribute():
                 self.add(LayeredSprite(x))
 
     scene = LayeredScene()
-    for lower_sprite, higher_sprite in zip(scene.sprite_layers(), list(scene.sprite_layers())[1:]):
+     for lower_sprite, higher_sprite in zip(scene.sprite_layers(), islice(scene.sprite_layers(), 1, None)):
         if isinstance(lower_sprite, camera.Camera) or isinstance(higher_sprite, camera.Camera):
             continue
         assert lower_sprite.layer < higher_sprite.layer

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -22,13 +22,13 @@ def test_layering_attribute_ints():
                 self.add(LayeredSprite(x))
 
     scene = LayeredScene()
-    for lower_sprite, higher_sprite in zip(scene.sprites(), list(scene.sprites())[1:]):
+    for lower_sprite, higher_sprite in zip(scene.sprite_layers(), list(scene.sprite_layers())[1:]):
         if isinstance(lower_sprite, camera.Camera) or isinstance(higher_sprite, camera.Camera):
             continue
         assert lower_sprite.layer < higher_sprite.layer
 
 
-def test_change_layer():
+def test_change_layer_ints():
 
     test_sprite = LayeredSprite(0)
     ones = tuple(LayeredSprite(1) for _ in range(3))
@@ -38,23 +38,39 @@ def test_change_layer():
     for sprite in ones:
         scene.add(sprite)
 
-    assert list(scene)[0] == test_sprite
+    assert list(scene.sprite_layers())[0] == test_sprite
 
     test_sprite.layer = 2
 
-    assert list(scene)[-1] == test_sprite
+    assert list(scene.sprite_layers())[-1] == test_sprite
 
 
-def test_registered_layers():
+def test_defined_layers():
 
-    scene = scenes.BaseScene()
+    class LayeredScene(scenes.BaseScene):
+        defined_layers = {
+            "background": 0,
+            "enemies": 2,
+            "players": 4,
+            "bullets": 6,
+        }
 
-    scene.define_layer("background", 0)
-    scene.define_layer("enemies", 1)
-    scene.define_layer("players", 2)
-    scene.define_layer("bullets", 3)
+    scene = LayeredScene()
 
-    assert scene.layers == {"background": 0, "enemies": 1, "players": 2, "bullets": 3}
+    assert scene.defined_layers == {"background": 0, "enemies": 2,
+                                    "players": 4, "bullets": 6}
+
+
+def test_defined_layers_sprites():
+    class LayeredScene(scenes.BaseScene):
+        defined_layers = {
+            "background": 0,
+            "enemies": 2,
+            "players": 4,
+            "bullets": 6,
+        }
+
+    scene = LayeredScene()
 
     scene.add(LayeredSprite("background"))
     for _ in range(3):
@@ -62,38 +78,38 @@ def test_registered_layers():
     scene.add(LayeredSprite("players"))
     scene.add(LayeredSprite("bullets"))
 
-    assert [s.layer for s in scene] == ["background", "enemies",  "enemies",
-                                        "enemies", "players", "bullets"]
+    assert [s.layer for s in scene.sprite_layers()] == ["background", "enemies",
+                                                        "enemies", "enemies",
+                                                        "players", "bullets"]
 
     assert len(list(scene.get(layer="background"))) == 1
     assert len(list(scene.get(layer="enemies"))) == 3
-    assert len(list(scene.get(layer=2))) == 1
+    assert len(list(scene.get(layer=4))) == 1
 
 
-def test_registered_layers_no_value():
+def test_layer_names():
 
-    scene = scenes.BaseScene()
+    class LayeredScene(scenes.BaseScene):
+        layer_names = ["background", "mobs", "projectiles", "particles"]
 
-    scene.define_layer("background")
-    scene.define_layer("mobs")
-    scene.define_layer("projectiles")
-    scene.define_layer("particles")
+    scene = LayeredScene()
 
-    assert scene.layers == {
-                            "background": 0,
-                            "mobs": 1,
-                            "projectiles": 2,
-                            "particles": 3
-                            }
+    assert scene.defined_layers == {
+                                    "background": 0,
+                                    "mobs": 1,
+                                    "projectiles": 2,
+                                    "particles": 3
+                                    }
 
-    scene = scenes.BaseScene()
-    scene.define_layer("background")
-    scene.define_layer("mobs", 3)
-    scene.define_layer("projectiles")
-    scene.define_layer("back_particles", 2)
-    scene.define_layer("fore_particles")
+    class NamesAndDefinitions(scenes.BaseScene):
+        defined_layers = {
+            "background": 0,
+            "back_particles": 2,
+        }
+        named_layers = ["mobs", "projectiles", "fore_particles"]
 
-    assert scene.layers == {
+    scene = NamesAndDefinitions
+    assert scene.defined_layers == {
                             "background": 0,
                             "back_particles": 2,
                             "mobs": 3,
@@ -111,11 +127,15 @@ def test_layering_without_layer_attribute():
     for x in range(1, 6):
         scene.add(LayeredSprite(x))
 
-    assert list(scene)[0] == test_sprite
+    assert list(scene.sprite_layers())[0] == test_sprite
 
-    scene = scenes.BaseScene()
-    scene.define_layer("background", 0)
-    scene.define_layer("foreground", 1)
+    class DefinedLayers(scenes.BaseScene):
+        named_layers = "background", "foreground"
+
+    scene = DefinedLayers()
+
+    scene.add(test_sprite)
+
     for _ in range(2):
         scene.add(LayeredSprite("background"))
         scene.add(LayeredSprite("foreground"))
@@ -124,10 +144,13 @@ def test_layering_without_layer_attribute():
 
 
 def test_named_layers_with_undefined_layer():
-    scene = scenes.BaseScene()
+    class LayeredScene(scenes.BaseScene):
+        defined_layers = {
+            "defined_layer": 2,
+            "defined_layer_2": 4
+        }
 
-    scene.define_layer("defined_layer", 2)
-    scene.define_layer("defined_layer_2", 4)
+    scene = LayeredScene()
 
     test_sprite = LayeredSprite("undefined_layer")
     scene.add(test_sprite)
@@ -136,17 +159,22 @@ def test_named_layers_with_undefined_layer():
 
     assert list(scene)[0] is test_sprite
 
-    scene.define_layer("undefined_layer", 6)
+    scene.defined_layer["undefined_layer"] = 6
 
     assert list(scene)[-1] is test_sprite
 
 
 def test_default_layer_named():
 
-    scene = scenes.BaseScene()
-    scene.define_layer("our_default", 5, default=True)
-    scene.define_layer("something_else", 2)
-    scene.define_layer("another", 2)
+    class LayeredScene(scenes.BaseScene):
+        defined_layers = {
+            "our_default": 5,
+            "something_else": 2,
+            "another": 3
+        }
+        _default_layer = "our_default"
+
+    scene = LayeredScene()
 
     test_object = NoLayer()
     scene.add(test_object)
@@ -156,10 +184,11 @@ def test_default_layer_named():
 
 def test_default_layer_set_layer():
 
-    scene = scenes.BaseScene()
-    scene.define_layer("background")
-    scene.define_layer("mobs")
-    scene.define_layer("particles")
+    class LayeredScene(scenes.BaseScene):
+        named_layers = ["background", "mobs", "particles"]
+        _default_layer = "particles"
+
+    scene = LayeredScene()
 
     scene.default_layer = "mobs"
     assert scene.default_layer == 1

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -40,7 +40,7 @@ def test_change_layer():
     for sprite in ones:
         scene.add(sprite)
 
-    assert list(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers()))[0] is test_sprite
+    assert next(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers())) is test_sprite
 
     test_sprite.layer = 2
 
@@ -56,4 +56,4 @@ def test_layering_without_layer_attribute():
     for x in range(1, 6):
         scene.add(LayeredSprite(x))
 
-    assert list(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers()))[0] is test_sprite
+    assert next(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers())) is test_sprite

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -24,7 +24,7 @@ def test_layering_attribute():
                 self.add(LayeredSprite(x))
 
     scene = LayeredScene()
-     for lower_sprite, higher_sprite in zip(scene.sprite_layers(), islice(scene.sprite_layers(), 1, None)):
+    for lower_sprite, higher_sprite in zip(scene.sprite_layers(), islice(scene.sprite_layers(), 1, None)):
         if isinstance(lower_sprite, camera.Camera) or isinstance(higher_sprite, camera.Camera):
             continue
         assert lower_sprite.layer < higher_sprite.layer

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -12,7 +12,7 @@ class NoLayer:
     pass
 
 
-def test_layering_attribute_ints():
+def test_layering_attribute():
 
     class LayeredScene(scenes.BaseScene):
 
@@ -28,7 +28,7 @@ def test_layering_attribute_ints():
         assert lower_sprite.layer < higher_sprite.layer
 
 
-def test_change_layer_ints():
+def test_change_layer():
 
     test_sprite = LayeredSprite(0)
     ones = tuple(LayeredSprite(1) for _ in range(3))
@@ -45,79 +45,6 @@ def test_change_layer_ints():
     assert list(scene.sprite_layers())[-1] == test_sprite
 
 
-def test_defined_layers():
-
-    class LayeredScene(scenes.BaseScene):
-        defined_layers = {
-            "background": 0,
-            "enemies": 2,
-            "players": 4,
-            "bullets": 6,
-        }
-
-    scene = LayeredScene()
-
-    assert scene.defined_layers == {"background": 0, "enemies": 2,
-                                    "players": 4, "bullets": 6}
-
-
-def test_defined_layers_sprites():
-    class LayeredScene(scenes.BaseScene):
-        defined_layers = {
-            "background": 0,
-            "enemies": 2,
-            "players": 4,
-            "bullets": 6,
-        }
-
-    scene = LayeredScene()
-
-    scene.add(LayeredSprite("background"))
-    for _ in range(3):
-        scene.add(LayeredSprite("enemies"))
-    scene.add(LayeredSprite("players"))
-    scene.add(LayeredSprite("bullets"))
-
-    assert [s.layer for s in scene.sprite_layers()] == ["background", "enemies",
-                                                        "enemies", "enemies",
-                                                        "players", "bullets"]
-
-    assert len(list(scene.get(layer="background"))) == 1
-    assert len(list(scene.get(layer="enemies"))) == 3
-    assert len(list(scene.get(layer=4))) == 1
-
-
-def test_layer_names():
-
-    class LayeredScene(scenes.BaseScene):
-        layer_names = ["background", "mobs", "projectiles", "particles"]
-
-    scene = LayeredScene()
-
-    assert scene.defined_layers == {
-                                    "background": 0,
-                                    "mobs": 1,
-                                    "projectiles": 2,
-                                    "particles": 3
-                                    }
-
-    class NamesAndDefinitions(scenes.BaseScene):
-        defined_layers = {
-            "background": 0,
-            "back_particles": 2,
-        }
-        named_layers = ["mobs", "projectiles", "fore_particles"]
-
-    scene = NamesAndDefinitions
-    assert scene.defined_layers == {
-                            "background": 0,
-                            "back_particles": 2,
-                            "mobs": 3,
-                            "projectiles": 4,
-                            "fore_particles": 5
-                            }
-
-
 def test_layering_without_layer_attribute():
 
     test_sprite = NoLayer()
@@ -129,66 +56,17 @@ def test_layering_without_layer_attribute():
 
     assert list(scene.sprite_layers())[0] == test_sprite
 
-    class DefinedLayers(scenes.BaseScene):
-        named_layers = "background", "foreground"
 
-    scene = DefinedLayers()
+def test_set_default_layer():
 
+    class DefaultLayer(scenes.BaseScene):
+        default_layer = 3
+
+    scene = DefaultLayer()
+
+    scene.add(LayeredSprite(layer=1))
+    scene.add(LayeredSprite(layer=5))
+    test_sprite = NoLayer()
     scene.add(test_sprite)
 
-    for _ in range(2):
-        scene.add(LayeredSprite("background"))
-        scene.add(LayeredSprite("foreground"))
-
-    assert test_sprite in scene.get(layer="background")
-
-
-def test_named_layers_with_undefined_layer():
-    class LayeredScene(scenes.BaseScene):
-        defined_layers = {
-            "defined_layer": 2,
-            "defined_layer_2": 4
-        }
-
-    scene = LayeredScene()
-
-    test_sprite = LayeredSprite("undefined_layer")
-    scene.add(test_sprite)
-    scene.add(LayeredSprite("defined_layer"))
-    scene.add(LayeredSprite("defined_layer_2"))
-
-    assert list(scene)[0] is test_sprite
-
-    scene.defined_layer["undefined_layer"] = 6
-
-    assert list(scene)[-1] is test_sprite
-
-
-def test_default_layer_named():
-
-    class LayeredScene(scenes.BaseScene):
-        defined_layers = {
-            "our_default": 5,
-            "something_else": 2,
-            "another": 3
-        }
-        default_layer = "our_default"
-
-    scene = LayeredScene()
-
-    test_object = NoLayer()
-    scene.add(test_object)
-
-    assert list(scene.get(layer="our_default")) == [test_object]
-
-
-def test_default_layer_set_layer():
-
-    class LayeredScene(scenes.BaseScene):
-        named_layers = ["background", "mobs", "particles"]
-        default_layer = "particles"
-
-    scene = LayeredScene()
-
-    scene.default_layer = "mobs"
-    assert scene.default_layer == "particles"
+    assert list(scene.sprite_layers)[1] is test_sprite

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -1,0 +1,66 @@
+import ppb.camera as camera
+import ppb.scenes as scenes
+
+
+class LayeredSprite:
+
+    def __init__(self, layer):
+        self.layer = layer
+
+
+def test_layering_attribute():
+
+    class LayeredScene(scenes.BaseScene):
+
+        def __init__(self):
+            super().__init__()
+            for x in range(5):
+                self.add(LayeredSprite(x))
+
+    scene = LayeredScene()
+    for lower_sprite, higher_sprite in zip(scene, list(scene)[1:]):
+        if isinstance(lower_sprite, camera.Camera) or isinstance(higher_sprite, camera.Camera):
+            continue
+        assert lower_sprite.layer < higher_sprite.layer
+
+
+def test_change_layer():
+
+    test_sprite = LayeredSprite(0)
+    ones = tuple(LayeredSprite(1) for _ in range(3))
+
+    scene = scenes.BaseScene()
+    scene.add(test_sprite)
+    for sprite in ones:
+        scene.add(sprite)
+
+    assert list(scene)[0] == test_sprite
+
+    test_sprite.layer = 2
+
+    assert list(scene)[-1] == test_sprite
+
+
+def test_registered_layers():
+
+    scene = scenes.BaseScene()
+
+    scene.define_layer("background", 0)
+    scene.define_layer("enemies", 1)
+    scene.define_layer("players", 2)
+    scene.define_layer("bullets", 3)
+
+    assert scene.layers == {"background": 0, "enemies": 1, "players": 2, "bullets": 3}
+
+    scene.add(LayeredSprite("background"))
+    for _ in range(3):
+        scene.add(LayeredSprite("enemies"))
+    scene.add(LayeredSprite("players"))
+    scene.add(LayeredSprite("bullets"))
+
+    assert [s.layer for s in scene] == ["background", "enemies",  "enemies",
+                                        "enemies", "players", "bullets"]
+
+    assert len(list(scene.get(layer="background"))) == 1
+    assert len(list(scene.get(layer="enemies"))) == 3
+    assert len(list(scene.get(layer=2))) == 1

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -40,11 +40,11 @@ def test_change_layer():
     for sprite in ones:
         scene.add(sprite)
 
-    assert list(scene.sprite_layers())[0] is test_sprite
+    assert list(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers()))[0] is test_sprite
 
     test_sprite.layer = 2
 
-    assert list(scene.sprite_layers())[-1] is test_sprite
+    assert list(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers()))[-1] is test_sprite
 
 
 def test_layering_without_layer_attribute():
@@ -56,4 +56,4 @@ def test_layering_without_layer_attribute():
     for x in range(1, 6):
         scene.add(LayeredSprite(x))
 
-    assert list(scene.sprite_layers())[0] is test_sprite
+    assert list(filter(lambda s: not isinstance(s, camera.Camera), scene.sprite_layers()))[0] is test_sprite


### PR DESCRIPTION
Implements a basic layering API.

`Sprites` can have a `layer` attribute that should be an integer, but due to implementation details could be a float.

Does not change the renderer as part of this change, will do so in a followup PR.

This is one step on the way to #276


Proposal:

* `BaseScene.sprite_layers()` which returns all sprites based on their layering order.
* Layers are simple attributes on `Sprites`.
* You can name layers via `BaseScene.named_layers` which will default to incrementing each layer number by 1.
* You can have greater control over your layer definition by providing `BaseScene.defined_layers` as Dict[str, int].
* There is a `BaseSprite.default_layer` which a Sprite without a layer attribute defaults to. It can be a string or an int as preferred by the end user.