### PR TITLE
Attempt a weakref-based texture cache

### DIFF
--- a/ppb/systems/_utils.py
+++ b/ppb/systems/_utils.py
@@ -1,0 +1,48 @@
+import collections.abc
+import functools
+import weakref
+
+__all__ = 'ObjectSideData',
+
+
+def _drop(self_ref, key, ref):
+    self = self_ref()
+    if self is not None:
+        try:
+            del self._data[key]
+        except KeyError:
+            pass
+
+
+class ObjectSideData(collections.abc.MutableMapping):
+    """
+    Similar to a WeakKeyDictionary, but tracks against object identity instead
+    of object value.
+    """
+    def __init__(self, values=None):
+        self._data = {}  # id: (ref, value)
+        if values:
+            self.update(values)
+
+    def __getitem__(self, key):
+        _, value = self._data[id(key)]
+        return value
+
+    def __delitem__(self, key):
+        del self._data[id(key)]
+
+    def __iter__(self):
+        for ref, _ in self._data.values():
+            key = ref()
+            if key is not None:
+                yield key
+
+    def __len__(self):
+        return len(self._data)
+
+    def __setitem__(self, key, value):
+        ref = weakref.ref(
+            key,
+            functools.partial(_drop, weakref.ref(self), id(key))
+        )
+        self._data[id(key)] = (ref, value)

--- a/tests/test_system_utils.py
+++ b/tests/test_system_utils.py
@@ -1,0 +1,21 @@
+import gc
+
+from ppb.systems._utils import ObjectSideData
+
+
+def test_osd_basic():
+    class Foo:
+        pass
+
+    myobj = Foo()
+
+    osd = ObjectSideData()
+
+    osd[myobj] = "foo"
+
+    assert osd[myobj] == "foo"
+
+    del myobj
+    gc.collect()
+
+    assert len(osd) == 0


### PR DESCRIPTION
This is an attempted texture cache, based on weakref.

TBH, the performance isn't where I hoped it would be.

(For comparison, I also did a version where I just did `image.__texture = texture`, but that's not usable because of eg things like `MorphToneProxy`.)