### PR TITLE
Add some hypothesis profiles

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+from hypothesis import settings
+settings.register_profile("x-large", max_examples=10000)
+settings.register_profile("large", max_examples=1000)
+settings.register_profile("jumbo", max_examples=500)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
 from hypothesis import settings
-settings.register_profile("x-large", max_examples=10000)
-settings.register_profile("large", max_examples=1000)
-settings.register_profile("jumbo", max_examples=500)
+settings.register_profile("x-large", max_examples=100*settings.default.max_examples)
+settings.register_profile("large", max_examples=10*settings.default.max_examples)
+settings.register_profile("jumbo", max_examples=5*settings.default.max_examples)


### PR DESCRIPTION
You can use these with `pytest --hypothesis-profile jumbo`.

The profiles defined have to do with the thoroughness of the hypothesis tests. Larger profiles mean more examples tested but longer run times.

1. `jumbo`: 5x more
2. `large`: 10x more
3. `x-large`: 100x more

The default is unaltered.