### PR TITLE
Apply alpha blend modes and coloration to textures based on sprite data.

### DIFF
--- a/ppb/flags.py
+++ b/ppb/flags.py
@@ -56,3 +56,34 @@ class DoNotRender(Flag):
     """
     Inform the renderer to ignore this object.
     """
+
+
+class BlendMode(Flag, abstract=True):
+    """
+    A flag indicating a blend mode, changing how translucent sprites are drawn
+    over top of other sprites.
+    """
+
+
+class BlendModeAdd(BlendMode):
+    """
+    Indicate a sprite, if translucent, should be rendered in ADD mode.
+    """
+
+
+class BlendModeBlend(BlendMode):
+    """
+    Indicate a sprite, if translucent, should be rendered in BLEND mode.
+    """
+
+
+class BlendModeMod(BlendMode):
+    """
+    Indicate a sprite, if translucent, should be rendered in MOD mode.
+    """
+
+
+class BlendModeNone(BlendMode):
+    """
+    Indicate a sprite, if translucent, should be rendered in NONE mode.
+    """

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -108,6 +108,9 @@ class RenderableMixin:
     #: (:py:class:`ppb.Image`): The image asset
     image = None  # TODO: Type hint appropriately
     size = 1
+    blend_mode: 'ppb.flags.BlendMode' # One of four blending modes
+    opacity: int # An opacity value from 0-255
+    color: 'ppb.utils.Color' # A 3-tuple color with values 0-255
 
     def __image__(self):
         """

--- a/ppb/systems/renderer.py
+++ b/ppb/systems/renderer.py
@@ -2,6 +2,7 @@ import ctypes
 import io
 import logging
 import random
+from typing import Tuple
 
 import sdl2
 import sdl2.ext
@@ -25,6 +26,11 @@ from sdl2 import (
     SDL_QueryTexture,  # https://wiki.libsdl.org/SDL_QueryTexture
     SDL_RenderCopyEx,  # https://wiki.libsdl.org/SDL_RenderCopyEx
     SDL_CreateRGBSurface,  # https://wiki.libsdl.org/SDL_CreateRGBSurface
+    SDL_BLENDMODE_ADD,
+    SDL_BLENDMODE_BLEND,
+    SDL_SetTextureAlphaMod,
+    SDL_SetTextureBlendMode,
+    SDL_SetTextureColorMod,
 )
 
 from sdl2.sdlimage import (
@@ -107,6 +113,9 @@ class SmartPointer:
 
 class Renderer(SdlSubSystem):
     _sdl_subsystems = SDL_INIT_VIDEO
+    last_opacity: int = 255
+    last_opacity_mode: str = 'blend'
+    last_color: Tuple[int, int, int] = (255, 255, 255)
 
     def __init__(
         self,
@@ -233,14 +242,41 @@ class Renderer(SdlSubSystem):
 
         surface = image.load()
         try:
-            return self._texture_cache[surface]
+            texture = self._texture_cache[surface]
         except KeyError:
             texture = SmartPointer(sdl_call(
                 SDL_CreateTextureFromSurface, self.renderer, surface,
                 _check_error=lambda rv: not rv
             ), SDL_DestroyTexture)
             self._texture_cache[surface] = texture
-            return texture
+
+        opacity = getattr(game_object, 'opacity', 255)
+        opacity_mode = getattr(game_object, 'opacity_mode', 'blend')
+        tint = getattr(game_object, 'tint', (255, 255, 255))
+
+        sdl_call(
+            SDL_SetTextureAlphaMod, texture.inner, opacity,
+            _check_error=lambda rv: rv < 0
+        )
+        if opacity_mode == 'add':
+            sdl_call(
+                SDL_SetTextureBlendMode, texture.inner, SDL_BLENDMODE_ADD,
+                _check_error=lambda rv: rv < 0
+            )
+        elif opacity_mode == 'blend':
+            sdl_call(
+                SDL_SetTextureBlendMode, texture.inner, SDL_BLENDMODE_BLEND,
+                _check_error=lambda rv: rv < 0
+            )
+        else:
+            raise ValueError(f"Support modes for translucent sprites are 'add' or 'blend', not '{opacity_mode}'.")
+
+        sdl_call(
+            SDL_SetTextureColorMod, texture.inner, tint[0], tint[1], tint[2],
+            _check_error=lambda rv: rv < 0
+        )
+
+        return texture
 
     def compute_rectangles(self, texture, game_object, camera):
         flags = sdl2.stdinc.Uint32()

--- a/ppb/systems/renderer.py
+++ b/ppb/systems/renderer.py
@@ -28,6 +28,8 @@ from sdl2 import (
     SDL_CreateRGBSurface,  # https://wiki.libsdl.org/SDL_CreateRGBSurface
     SDL_BLENDMODE_ADD,
     SDL_BLENDMODE_BLEND,
+    SDL_BLENDMODE_MOD,
+    SDL_BLENDMODE_NONE,
     SDL_SetTextureAlphaMod,
     SDL_SetTextureBlendMode,
     SDL_SetTextureColorMod,
@@ -57,6 +59,13 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_RESOLUTION = 800, 600
+
+OPACITY_MODES = {
+    flags.BlendModeAdd: SDL_BLENDMODE_ADD,
+    flags.BlendModeBlend: SDL_BLENDMODE_BLEND,
+    flags.BlendModeMod: SDL_BLENDMODE_MOD,
+    flags.BlendModeNone: SDL_BLENDMODE_NONE,
+}
 
 
 # TODO: Move Image out of the renderer so sprites can type hint appropriately.
@@ -113,9 +122,6 @@ class SmartPointer:
 
 class Renderer(SdlSubSystem):
     _sdl_subsystems = SDL_INIT_VIDEO
-    last_opacity: int = 255
-    last_opacity_mode: str = 'blend'
-    last_color: Tuple[int, int, int] = (255, 255, 255)
 
     def __init__(
         self,
@@ -251,25 +257,19 @@ class Renderer(SdlSubSystem):
             self._texture_cache[surface] = texture
 
         opacity = getattr(game_object, 'opacity', 255)
-        opacity_mode = getattr(game_object, 'opacity_mode', 'blend')
+        opacity_mode = getattr(game_object, 'opacity_mode', flags.BlendModeBlend)
+        opacity_mode = OPACITY_MODES[opacity_mode]
         tint = getattr(game_object, 'tint', (255, 255, 255))
 
         sdl_call(
             SDL_SetTextureAlphaMod, texture.inner, opacity,
             _check_error=lambda rv: rv < 0
         )
-        if opacity_mode == 'add':
-            sdl_call(
-                SDL_SetTextureBlendMode, texture.inner, SDL_BLENDMODE_ADD,
-                _check_error=lambda rv: rv < 0
-            )
-        elif opacity_mode == 'blend':
-            sdl_call(
-                SDL_SetTextureBlendMode, texture.inner, SDL_BLENDMODE_BLEND,
-                _check_error=lambda rv: rv < 0
-            )
-        else:
-            raise ValueError(f"Support modes for translucent sprites are 'add' or 'blend', not '{opacity_mode}'.")
+
+        sdl_call(
+            SDL_SetTextureBlendMode, texture.inner, opacity_mode,
+            _check_error=lambda rv: rv < 0
+        )
 
         sdl_call(
             SDL_SetTextureColorMod, texture.inner, tint[0], tint[1], tint[2],

--- a/ppb/utils.py
+++ b/ppb/utils.py
@@ -2,9 +2,12 @@ import logging
 import re
 import sys
 from time import perf_counter
+import typing
 
-__all__ = 'LoggingMixin', 'camel_to_snake', 'get_time'
+__all__ = 'LoggingMixin', 'camel_to_snake', 'get_time', 'Color'
 
+
+Color = typing.Tuple[int, int, int]
 
 # Dictionary mapping file names -> module names
 _module_file_index = {}


### PR DESCRIPTION
I know there was debate before about where `opacity` and `color` data should live, but i wanted to open the PR with the customizations I've been using to start the discussion again with something concrete.