### PR TITLE
Add RectangleSprite to ppb root module

### DIFF
--- a/docs/reference/sprites.rst
+++ b/docs/reference/sprites.rst
@@ -19,7 +19,7 @@ the primary classes you subclass when building game objects.
    :members:
    :inherited-members:
 
-.. autoclass:: ppb.sprites.RectangleSprite
+.. autoclass:: ppb.RectangleSprite
    :members:
    :inherited-members:
 

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -41,6 +41,7 @@ from ppb.assets import Square
 from ppb.assets import Triangle
 from ppb.engine import GameEngine
 from ppb.scenes import BaseScene
+from ppb.sprites import RectangleSprite
 from ppb.sprites import Sprite
 from ppb.systems import Image
 from ppb.systems import Sound
@@ -50,7 +51,7 @@ from ppb.utils import get_time
 
 __all__ = (
     # Shortcuts
-    'Vector', 'BaseScene', 'Circle', 'Image', 'Sprite',
+    'Vector', 'BaseScene', 'Circle', 'Image', 'Sprite', 'RectangleSprite',
     'Square', 'Sound', 'Triangle', 'events', 'Font', 'Text', 'directions',
     # Local stuff
     'run', 'make_engine',


### PR DESCRIPTION
I just noticed that `RectangleSprite` is only available from `ppb.sprites`, but it should probably be available on `ppb` as well.