### PR TITLE
Rendering context: A place to hold rendering related values

### DIFF
--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -33,6 +33,7 @@ import logging
 import warnings
 from typing import Callable
 
+from ppb import contexts
 from ppb import directions
 from ppb import events
 from ppb_vector import Vector
@@ -53,6 +54,7 @@ __all__ = (
     # Shortcuts
     'Vector', 'BaseScene', 'Circle', 'Image', 'Sprite', 'RectangleSprite',
     'Square', 'Sound', 'Triangle', 'events', 'Font', 'Text', 'directions',
+    'contexts',
     # Local stuff
     'run', 'make_engine',
 )

--- a/ppb/contexts.py
+++ b/ppb/contexts.py
@@ -1,13 +1,10 @@
 from dataclasses import dataclass
-from typing import Optional, Type, Union
+from typing import Any, Optional, Type
 
 from ppb.flags import BlendMode, BlendModeBlend
-from ppb.assets import Shape
-from ppb.systems.renderer import Image
 from ppb.utils import Color
 
 
-KnownImages = Union[Ellipsis, Shape, Image]
 
 @dataclass
 class RenderInfo:
@@ -15,9 +12,9 @@ class RenderInfo:
     A context class for holding information relevant to rendering.
     """
     #: The image asset.
-    image: Optional[KnownImages] = None
+    image: Any = ...
     #: The blend mode to use for opacity.
     blend_mode: Type[BlendMode] = BlendModeBlend  # This is apparently the appropriate way to type hint our flags?
     #:
     opacity: int = 255
-    color: Optional[Color] = None
+    tint: Optional[Color] = None

--- a/ppb/contexts.py
+++ b/ppb/contexts.py
@@ -1,0 +1,23 @@
+from dataclasses import dataclass
+from typing import Optional, Type, Union
+
+from ppb.flags import BlendMode, BlendModeBlend
+from ppb.assets import Shape
+from ppb.systems.renderer import Image
+from ppb.utils import Color
+
+
+KnownImages = Union[Ellipsis, Shape, Image]
+
+@dataclass
+class RenderInfo:
+    """
+    A context class for holding information relevant to rendering.
+    """
+    #: The image asset.
+    image: Optional[KnownImages] = None
+    #: The blend mode to use for opacity.
+    blend_mode: Type[BlendMode] = BlendModeBlend  # This is apparently the appropriate way to type hint our flags?
+    #:
+    opacity: int = 255
+    color: Optional[Color] = None

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -23,6 +23,7 @@ from typing import Union
 from ppb_vector import Vector, VectorLike
 
 import ppb
+from ppb import flags
 
 __all__ = (
     "BaseSprite",
@@ -111,13 +112,17 @@ class RenderableMixin:
     blend_mode: 'ppb.flags.BlendMode' # One of four blending modes
     opacity: int # An opacity value from 0-255
     color: 'ppb.utils.Color' # A 3-tuple color with values 0-255
+    render_info: ppb.contexts.RenderInfo = ppb.contexts.RenderInfo()
 
-    def __image__(self):
+    def __image__(self):  # This might go away as I work on this.
         """
         Returns the sprite's image attribute if provided, or sets a default
         one.
         """
-        if self.image is ...:
+        if self.render_info.image is None:
+            self.render_info.image = self.image
+
+        if self.render_info.image is ...:
             klass = type(self)
             prefix = Path(klass.__module__.replace('.', '/'))
             try:
@@ -128,10 +133,10 @@ class RenderableMixin:
                 if Path(klassfile).name != '__init__.py':
                     prefix = prefix.parent
             if prefix == Path('.'):
-                self.image = ppb.Image(f"{klass.__name__.lower()}.png")
+                self.render_info.image = ppb.Image(f"{klass.__name__.lower()}.png")
             else:
-                self.image = ppb.Image(f"{prefix!s}/{klass.__name__.lower()}.png")
-        return self.image
+                self.render_info.image = ppb.Image(f"{prefix!s}/{klass.__name__.lower()}.png")
+        return self.render_info.image
 
 
 class RotatableMixin:

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -112,14 +112,15 @@ class RenderableMixin:
     blend_mode: 'ppb.flags.BlendMode' # One of four blending modes
     opacity: int # An opacity value from 0-255
     color: 'ppb.utils.Color' # A 3-tuple color with values 0-255
-    render_info: ppb.contexts.RenderInfo = ppb.contexts.RenderInfo()
+    render_info: ppb.contexts.RenderInfo = None
 
     def __image__(self):  # This might go away as I work on this.
         """
         Returns the sprite's image attribute if provided, or sets a default
         one.
         """
-        if self.render_info.image is None:
+        if self.render_info is None:
+            self.render_info = ppb.contexts.RenderInfo()
             self.render_info.image = self.image
 
         if self.render_info.image is ...:


### PR DESCRIPTION
The basic idea is simple: Instead of sprites growing more and more data, we store them on a context object.

As we continue to add rendering options, we've been adding more and more symbols to the RenderableMixin. This creates an issue as we are taking up simple words end users might want to use for other purposes. This is a proposal for a way to manage this via a context object: A dataclass that holds all of the relevant details the Renderer cares about.

This PR tries to maintain backwards compatibility with the previous model, but if we go this route we can discuss how best to sunset the old patterns going forward.

## Things to continue supporting

```python
Sprite.image = ImageAsset
```

This should continue to work. It current does at definition time, but after the rendering_info exists, this stops working. Want to think on the best way to implement that before we do.

## Nice to haves

I would like to make simple access available still, but doing that could explode the complexity of this API and create a problem where we're adding a bunch of tokens to sprites, plus our new one. Maybe we could ship a feature that takes the things in RenderInfo and adds pass through properties as a mixin? Supports a best of both worlds, without actually requiring all of those attributes be used the way we want them to be, and lets end users opt in to adding to their name spaces.

## Problems

This PR represents a new type of ppb object (`contexts`) and I'd like us to examine if this is the best way. They're just dataclasses, which means minimal maintenance, but added complexity and moving us closer to a true ECS. (Which. . . let's be real #500 is already moving us closer to that world anyway.)

Open to comments will update this document to make sure the discussion is encapsulated well.