### PR TITLE
Add custom error for when a user adds a type to a scene -- Closes #470

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,3 +34,4 @@ Halle Jones|HJones@aliacy.com||
 [Serin Delaunay](https://github.com/serin-delaunay) | | [SerinDelaunay](https://twitter.com/SerinDelaunay)
 [Nils Müller](https://github.com/shimst3r) | [shimst3r@gmail.com](mailto:shimst3r@gmail.com) | [@shimst3r](https://twitter.com/shimst3r)
 [Aly Sivji](https://github.com/alysivji) |  | [@CaiusSivjus](https://twitter.com/CaiusSivjus)
+[Mfon Eti-mfon](https://github.com/mfonism) | [mfon@etimfon.com](mfon@etimfon.com) | [mfonism](https://twitter.com/mfonism)

--- a/ppb/errors.py
+++ b/ppb/errors.py
@@ -23,3 +23,17 @@ def {method}({e_name.lower()}_event: {e_name}, signal_function):
     (Your code goes here.)
 """
         super().__init__(message)
+
+
+class BadChildException(Exception):
+    """Raised when a type (as opposed to an instance object) is used as a child."""
+
+    def __init__(self, child):
+        type_name = child.__name__
+        message = (
+            f"Argument child must be an instance object"
+            f" -- you passed in a type, {type_name}, instead."
+            f"\nThis probably isn't what you intended."
+            f"\n\nTry instantiating it, like: {type_name}()"
+        )
+        super().__init__(message)

--- a/ppb/gomlib.py
+++ b/ppb/gomlib.py
@@ -10,6 +10,8 @@ from typing import Iterator
 from typing import Type
 import warnings
 
+from ppb.errors import BadChildException
+
 
 class Children(Collection):
     """
@@ -46,6 +48,9 @@ class Children(Collection):
 
             children.add(MyObject(), tags=("red", "blue")
         """
+        if isinstance(child, type):
+            raise BadChildException(child)
+
         if isinstance(tags, (str, bytes)):
             raise TypeError("You passed a string instead of an iterable, this probably isn't what you intended.\n\nTry making it a tuple.")
         self._all.add(child)

--- a/tests/test_gom.py
+++ b/tests/test_gom.py
@@ -1,5 +1,6 @@
 import pytest
 
+from ppb.errors import BadChildException
 from ppb.gomlib import GameObject, Children
 
 
@@ -48,6 +49,12 @@ def test_add_methods(container, player, enemies):
     assert player in container
     for enemy in enemies:
         assert enemy in container
+
+
+@pytest.mark.parametrize("container", containers())
+def test_add_type_to_game_object(container):
+    with pytest.raises(BadChildException):
+        container.add(TestSprite)
 
 
 @pytest.mark.parametrize("player, container", players_and_containers())


### PR DESCRIPTION
This PR adds a cleaner, more descriptive, custom error for when a type is added to a scene, as per #470 