### PR TITLE
Add 'libmodplug' to RHEL prereqs in docs

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -70,7 +70,7 @@ Debian, Ubuntu::
 
 Fedora, CentOS, RHEL ::
 
-    sudo dnf install SDL2 SDL2_ttf SDL2_image SDL2_gfx SDL2_mixer
+    sudo dnf install SDL2 SDL2_ttf SDL2_image SDL2_gfx SDL2_mixer libmodplug
 
 You should see a few libraries get put together in your terminal, and when
 you have a prompt again, we're ready to go!


### PR DESCRIPTION
## Error

Version: `0.9.0`
OS: `Linux (Fedora Silverblue)`

I was getting an exception on run due to `MIX_INIT_MOD` from the following code being passed into `Mix_Init`:
https://github.com/ppb/pursuedpybear/blob/f34fed3cd34b9b5da2629bbc0e4de29c17619b56/ppb/systems/sound.py#L88

Looking into this, I found that this is due to the `SDL2_mixer` binary build for Fedora is missing the `MOD` support for whatever reason. 

Full error (when missing package) for reference:
```
Traceback (most recent call last):
  File "main.py", line 12, in <module>
    ppb.run(setup=setup)
  File "/var/home/vetra/Projects/build-ppb-action/test_project/.venv/lib/python3.7/site-packages/ppb/__init__.py", line 122, in run
    with make_engine(setup, starting_scene=starting_scene, title=title, **engine_opts) as eng:
  File "/var/home/vetra/Projects/build-ppb-action/test_project/.venv/lib/python3.7/site-packages/ppb/engine.py", line 107, in __enter__
    self.start_systems()
  File "/var/home/vetra/Projects/build-ppb-action/test_project/.venv/lib/python3.7/site-packages/ppb/engine.py", line 124, in start_systems
    self.exit_stack.enter_context(system)
  File "/usr/lib64/python3.7/contextlib.py", line 427, in enter_context
    result = _cm_type.__enter__(cm)
  File "/var/home/vetra/Projects/build-ppb-action/test_project/.venv/lib/python3.7/site-packages/ppb/systems/sound.py", line 88, in __enter__
    mix_call(Mix_Init, MIX_INIT_FLAC | MIX_INIT_MOD | MIX_INIT_MP3 | MIX_INIT_OGG)
  File "/var/home/vetra/Projects/build-ppb-action/test_project/.venv/lib/python3.7/site-packages/ppb/systems/_sdl_utils.py", line 94, in mix_call
    raise SdlMixerError(f"Error calling {func.__name__}: {err.decode('utf-8')}")
ppb.systems._sdl_utils.SdlMixerError: Error calling Mix_Init: MOD support not available
```

## Solution

To solve this error I installed the `libmodplug` package.

## Code Changes

This PR just updates the docs to include the `libmodplug` package for Fedora, Centos, and RHEL.