### PR TITLE
gomlib: use deque instead of list for walk()

### DIFF
--- a/ppb/gomlib.py
+++ b/ppb/gomlib.py
@@ -208,7 +208,7 @@ def walk(root):
 
     Is non-recursive.
     """
-    q = deque(root)
+    q = deque([root])
     while q:
         cur = q.popleft()
         yield cur

--- a/ppb/gomlib.py
+++ b/ppb/gomlib.py
@@ -1,7 +1,7 @@
 """
 The Game Object Model.
 """
-from collections import defaultdict
+from collections import defaultdict, deque
 from collections.abc import Collection
 from typing import Hashable
 from typing import Iterable
@@ -208,9 +208,9 @@ def walk(root):
 
     Is non-recursive.
     """
-    q = [root]
+    q = deque(root)
     while q:
-        cur = q.pop(0)
+        cur = q.pop()
         yield cur
         if hasattr(cur, 'children'):
             q.extend(cur.children)

--- a/ppb/gomlib.py
+++ b/ppb/gomlib.py
@@ -210,7 +210,7 @@ def walk(root):
     """
     q = deque(root)
     while q:
-        cur = q.pop()
+        cur = q.popleft()
         yield cur
         if hasattr(cur, 'children'):
             q.extend(cur.children)


### PR DESCRIPTION
Exactly what it says on the tin.

This should be a performance improvement.