### PR TITLE
Rename BaseScene to Scene #569

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,4 +39,4 @@ Halle Jones|HJones@aliacy.com||
 [Ian Clark](https://github.com/ace510) | [ianhclark510@gmail.com] | [ianhclark510](https://twitter.com/ianhclark510)
 [Casey Faist](https://github.com/caseyfaist) |  | [cfactoid](https://twitter.com/cfactoid)
 [Jürgen Gmach](https://jugmac00.github.io/) | [juergen.gmach@googlemail.com](juergen.gmach@googlemail.com) | [@jugmac00](https://twitter.com/jugmac00)
-[Morisa Manzella](https://github.com/mgmanzella) |
+[Morisa Manzella](https://github.com/mgmanzella) | |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -39,3 +39,4 @@ Halle Jones|HJones@aliacy.com||
 [Ian Clark](https://github.com/ace510) | [ianhclark510@gmail.com] | [ianhclark510](https://twitter.com/ianhclark510)
 [Casey Faist](https://github.com/caseyfaist) |  | [cfactoid](https://twitter.com/cfactoid)
 [Jürgen Gmach](https://jugmac00.github.io/) | [juergen.gmach@googlemail.com](juergen.gmach@googlemail.com) | [@jugmac00](https://twitter.com/jugmac00)
+[Morisa Manzella](https://github.com/mgmanzella) |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ ppb runs on the latest Python.
 
 `ppb` games are built out of instances of objects. Each object only has enough
 information to respond to the event provided, which always includes the current
-`BaseScene`. Because `ppb` doesn't have a master list of events, you can
+`Scene`. Because `ppb` doesn't have a master list of events, you can
 provide new ones simply to add more granular control over your game.
 
 ### Hardware Library Agnostic

--- a/docs/reference/scenes.rst
+++ b/docs/reference/scenes.rst
@@ -7,7 +7,7 @@ All About Scenes
 Scenes are the terrain where sprites act. Each game has multiple scenes and may
 transition at any time.
 
-.. autoclass:: ppb.BaseScene
+.. autoclass:: ppb.Scene
     :members:
     :exclude-members: container_class
 

--- a/examples/external_event_loop_integration/targets_with_twisted.py
+++ b/examples/external_event_loop_integration/targets_with_twisted.py
@@ -90,7 +90,7 @@ class Target(ppb.Sprite):
     radius = 0.5
 
 
-class GameScene(ppb.BaseScene):
+class GameScene(ppb.Scene):
     def __init__(self, *p, **kw):
         super().__init__(*p, **kw)
 

--- a/examples/frame_count/framecount.py
+++ b/examples/frame_count/framecount.py
@@ -11,7 +11,7 @@ import time
 import ppb
 
 
-class TestScene(ppb.BaseScene):
+class TestScene(ppb.Scene):
     """
     A view that prints a test line in place of rendering frames.
     """

--- a/examples/keyboard_and_mouse_controls/targets.py
+++ b/examples/keyboard_and_mouse_controls/targets.py
@@ -72,7 +72,7 @@ class Target(ppb.Sprite):
     radius = 0.5
 
 
-class GameScene(ppb.BaseScene):
+class GameScene(ppb.Scene):
     def __init__(self, *p, **kw):
         super().__init__(*p, **kw)
 

--- a/examples/loading_screen/main.py
+++ b/examples/loading_screen/main.py
@@ -14,7 +14,7 @@ class LoadingSprite(ppb.Sprite):
         self.image = self.waiting_image
 
 
-class Game(ppb.BaseScene):
+class Game(ppb.Scene):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -4,7 +4,7 @@ A python game framework.
 PursuedPyBear is object oriented and event driven. Practically, this means that
 most of your code will be organized into classes. Game objects in
 :mod:`ppb` are :class:`Sprite` instances, which get contained in
-:class:`BaseScenes <BaseScene>`. In turn, the :class:`GameEngine`
+:class:`Scenes <Scene>`. In turn, the :class:`GameEngine`
 contains the scenes and :class:`Systems <System>`.
 :mod:`Events <events>` are defined as simple classes and event handlers
 are based on their names.
@@ -16,7 +16,7 @@ make_engine). Advanced features tend to be in their own modules and subpackages.
 Exports:
 
 * :class:`~ppb_vector.Vector`
-* :class:`BaseScene`
+* :class:`Scene`
 * :class:`Circle`
 * :class:`Image`
 * :class:`Sprite`
@@ -41,7 +41,7 @@ from ppb.assets import Rectangle
 from ppb.assets import Square
 from ppb.assets import Triangle
 from ppb.engine import GameEngine
-from ppb.scenes import BaseScene
+from ppb.scenes import Scene
 from ppb.sprites import RectangleSprite
 from ppb.sprites import Sprite
 from ppb.systems import Image
@@ -52,7 +52,7 @@ from ppb.utils import get_time
 
 __all__ = (
     # Shortcuts
-    'Vector', 'BaseScene', 'Circle', 'Image', 'Sprite', 'RectangleSprite',
+    'Vector', 'Scene', 'Circle', 'Image', 'Sprite', 'RectangleSprite',
     'Square', 'Sound', 'Triangle', 'events', 'Font', 'Text', 'directions',
     'Rectangle', 'Ellipse',
     # Local stuff
@@ -72,8 +72,8 @@ def _make_kwargs(setup, title, engine_opts):
     return kwargs
 
 
-def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
-        starting_scene=BaseScene, title="PursuedPyBear", **engine_opts):
+def run(setup: Callable[[Scene], None] = None, *, log_level=logging.WARNING,
+        starting_scene=Scene, title="PursuedPyBear", **engine_opts):
     """
     Run a game.
 
@@ -94,7 +94,7 @@ def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
 
        import ppb
 
-       class Game(ppb.BaseScene):
+       class Game(ppb.Scene):
            def __init__(self, **kwargs):
                super().__init__(**kwargs)
                self.add(ppb.Sprite())
@@ -108,11 +108,11 @@ def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
 
     :param setup: Called with the first scene to allow initialization of
        your game.
-    :type setup: Callable[[BaseScene], None]
+    :type setup: Callable[[Scene], None]
     :param log_level: The logging level from :func:`logging` to send to the
        console.
     :param starting_scene: A scene class to use. Defaults to
-       :class:`~ppb.scenes.BaseScene`
+       :class:`~ppb.scenes.Scene`
     :type starting_scene: type
     :param title: The title of the rendered window.
     :type title: str
@@ -125,8 +125,8 @@ def run(setup: Callable[[BaseScene], None] = None, *, log_level=logging.WARNING,
         eng.run()
 
 
-def make_engine(setup: Callable[[BaseScene], None] = None, *,
-                starting_scene=BaseScene, title="PursedPyBear",
+def make_engine(setup: Callable[[Scene], None] = None, *,
+                starting_scene=Scene, title="PursedPyBear",
                 **engine_opts):
     """
     Setup a :class:`GameEngine`.
@@ -138,9 +138,9 @@ def make_engine(setup: Callable[[BaseScene], None] = None, *,
 
     :param setup: Called with the first scene to allow initialization of
        your game.
-    :type setup: Callable[[BaseScene], None]
+    :type setup: Callable[[Scene], None]
     :param starting_scene: A scene class to use. Defaults to
-       :class:`~ppb.scenes.BaseScene`
+       :class:`~ppb.scenes.Scene`
     :type starting_scene: type
     :param title: The title of the rendered window.
     :type title: str

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -41,6 +41,7 @@ from ppb.assets import Rectangle
 from ppb.assets import Square
 from ppb.assets import Triangle
 from ppb.engine import GameEngine
+from ppb.scenes import BaseScene
 from ppb.scenes import Scene
 from ppb.sprites import RectangleSprite
 from ppb.sprites import Sprite
@@ -52,7 +53,7 @@ from ppb.utils import get_time
 
 __all__ = (
     # Shortcuts
-    'Vector', 'Scene', 'Circle', 'Image', 'Sprite', 'RectangleSprite',
+    'Vector', 'BaseScene', 'Scene', 'Circle', 'Image', 'Sprite', 'RectangleSprite',
     'Square', 'Sound', 'Triangle', 'events', 'Font', 'Text', 'directions',
     'Rectangle', 'Ellipse',
     # Local stuff

--- a/ppb/engine.py
+++ b/ppb/engine.py
@@ -22,7 +22,7 @@ from ppb.gomlib import Children, GameObject
 from ppb.gomlib import walk
 from ppb.errors import BadChildException
 from ppb.errors import BadEventHandlerException
-from ppb.scenes import BaseScene
+from ppb.scenes import Scene
 from ppb.systems import EventPoller
 from ppb.systems import Renderer
 from ppb.systems import SoundController
@@ -91,7 +91,7 @@ class EngineChildren(Children):
         The top of the scene stack.
 
         :return: The currently running scene.
-        :rtype: ppb.BaseScene
+        :rtype: ppb.Scene
         """
         try:
             return self._scenes[-1]
@@ -121,7 +121,7 @@ class EngineChildren(Children):
         if isinstance(tags, (str, bytes)):
             raise TypeError("You passed a string instead of an iterable, this probably isn't what you intended.\n\nTry making it a tuple.")
 
-        if isinstance(child, ppb.BaseScene):
+        if isinstance(child, ppb.Scene):
             raise TypeError("Scenes must be pushed, not added. You probably want the StartScene or ReplaceScene events.")
         elif isinstance(child, ppb.systemslib.System):
             if self.entered:
@@ -150,7 +150,7 @@ class EngineChildren(Children):
             container.remove(myObject)
         """
         # Ugh, this is a copy of the implementation in Children.
-        if isinstance(child, ppb.BaseScene):
+        if isinstance(child, ppb.Scene):
             raise TypeError("Scenes must be popped, not removed. You probably want the StopScene event.")
         elif isinstance(child, ppb.systemslib.System):
             if self.entered:
@@ -217,15 +217,15 @@ class GameEngine(GameObject, LoggingMixin):
 
     To use the engine directly, treat it as a context manager: ::
 
-       with GameEngine(BaseScene, **kwargs) as ge:
+       with GameEngine(Scene, **kwargs) as ge:
            ge.run()
     """
-    def __init__(self, first_scene: Union[Type, BaseScene], *,
+    def __init__(self, first_scene: Union[Type, Scene], *,
                  basic_systems=(Renderer, Updater, EventPoller, SoundController, AssetLoadingSystem),
                  systems=(), scene_kwargs=None, **kwargs):
         """
-        :param first_scene: A :class:`~ppb.BaseScene` type.
-        :type first_scene: Union[Type, scenes.BaseScene]
+        :param first_scene: A :class:`~ppb.Scene` type.
+        :type first_scene: Union[Type, scenes.Scene]
         :param basic_systems: :class:systemslib.Systems that are considered
            the "default". Includes: :class:`~systems.Renderer`,
            :class:`~systems.Updater`, :class:`~systems.EventPoller`,
@@ -266,7 +266,7 @@ class GameEngine(GameObject, LoggingMixin):
         The top of the scene stack.
 
         :return: The currently running scene.
-        :rtype: ppb.BaseScene
+        :rtype: ppb.Scene
         """
         return self.children.current_scene
 
@@ -300,7 +300,7 @@ class GameEngine(GameObject, LoggingMixin):
 
         Example: ::
 
-           GameEngine(BaseScene, **kwargs).run()
+           GameEngine(Scene, **kwargs).run()
         """
         if not self.entered:
             with self:

--- a/ppb/events.py
+++ b/ppb/events.py
@@ -47,7 +47,7 @@ __all__ = (
 
 # Remember to define scene at the end so the pargs version of __init__() still works
 
-from ppb.scenes import BaseScene
+from ppb.scenes import Scene
 from ppb.buttons import MouseButton
 from ppb.keycodes import KeyCode
 from ppb_vector import Vector
@@ -66,7 +66,7 @@ class ButtonPressed:
     """
     button: MouseButton
     position: Vector  # Scene position
-    scene: BaseScene = None
+    scene: Scene = None
 
 
 @dataclass
@@ -81,7 +81,7 @@ class ButtonReleased:
     """
     button: MouseButton  #: A mouse button: Primary, Secondary, or Tertiary
     position: Vector  #: The game-world position of the event.
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -106,9 +106,9 @@ class StartScene:
        In general, you should not respond to :class:`StartScene`, if you want to respond to
        a new scene, see :class:`SceneStarted`.
     """
-    new_scene: Union[BaseScene, Type[BaseScene]]  #: A :class:`~ppb.scenes.BaseScene` class or instance
+    new_scene: Union[Scene, Type[Scene]]  #: A :class:`~ppb.scenes.Scene` class or instance
     kwargs: Dict[str, Any] = None  #: Keyword arguments to be passed to a scene type.
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -123,7 +123,7 @@ class KeyPressed:
     """
     key: KeyCode  #: A :class:`~ppb.keycodes.KeyCode` flag.
     mods: Set[KeyCode]  #: A set of :class:`KeyCodes <ppb.keycodes.KeyCode>`
-    scene: BaseScene = None  #: The currently running scene
+    scene: Scene = None  #: The currently running scene
 
 
 @dataclass
@@ -138,7 +138,7 @@ class KeyReleased:
     """
     key: KeyCode  #: A :class:`~ppb.keycodes.KeyCode` flag.
     mods: Set[KeyCode]  #: A set of :class:`KeyCodes <ppb.keycodes.KeyCode>`
-    scene: BaseScene = None  #: The currently running scene
+    scene: Scene = None  #: The currently running scene
 
 
 @dataclass
@@ -151,7 +151,7 @@ class MouseMotion:
     position: Vector  #: The game-world location of the mouse cursor.
     delta: Vector  #: The change in position since the last :class:`MouseMotion` event.
     buttons: Collection[MouseButton]  #: The state of the mouse buttons.
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -164,7 +164,7 @@ class PreRender:
     position of the camera) should happen ``on_pre_render``.
     """
     time_delta: float  #: Seconds since last PreRender.
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -184,7 +184,7 @@ class Quit:
 
     Respond with ``on_quit`` to perform any shut down tasks (like saving data.)
     """
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -197,7 +197,7 @@ class Render:
        render pass. If you want changes to effect this frame, see
        :class:`PreRender`
     """
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -222,9 +222,9 @@ class ReplaceScene:
        In general, you should not respond to :class:`ReplaceScene`, if you want to
        respond to a new scene, see :class:`SceneStarted`.
     """
-    new_scene: Union[BaseScene, Type[BaseScene]]  #: A :class:`~ppb.scenes.BaseScene` class or instance
+    new_scene: Union[Scene, Type[Scene]]  #: A :class:`~ppb.scenes.Scene` class or instance
     kwargs: Dict[str, Any] = None  #: Keyword arguments to be passed to a scene type.
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -238,7 +238,7 @@ class SceneContinued:
     From the middle of the event lifetime that begins with
     :class:`SceneStarted`.
     """
-    scene: BaseScene = None  #: The scene that is resuming.
+    scene: Scene = None  #: The scene that is resuming.
 
 
 @dataclass
@@ -259,7 +259,7 @@ class SceneStarted:
     3. Optionally, Repeatable: :class:`SceneContinued`
     4. Optionally: :class:`SceneStopped`
     """
-    scene: BaseScene = None  #: The scene that is starting.
+    scene: Scene = None  #: The scene that is starting.
 
 
 @dataclass
@@ -275,7 +275,7 @@ class SceneStopped:
 
     This is the end of the scene lifetime, see :class:`SceneStarted`.
     """
-    scene: BaseScene = None  #: The scene that is stopping.
+    scene: Scene = None  #: The scene that is stopping.
 
 
 @dataclass
@@ -289,7 +289,7 @@ class ScenePaused:
 
     A middle event in the scene lifetime, started with :class:`SceneStarted`.
     """
-    scene: BaseScene = None  #: The scene that has paused.
+    scene: Scene = None  #: The scene that has paused.
 
 
 @dataclass
@@ -308,7 +308,7 @@ class StopScene:
        In general, you should not respond to :class:`StopScene`, if you want to respond
        to a scene ending, see :class:`SceneStopped`.
     """
-    scene: BaseScene = None  #: The scene that is stopping.
+    scene: Scene = None  #: The scene that is stopping.
 
 
 @dataclass
@@ -320,7 +320,7 @@ class Idle:
     This is an engine plumbing event to pump timing information to subsystems.
     """
     time_delta: float  #: Seconds since last Idle.
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass
@@ -333,7 +333,7 @@ class Update:
     your on_update methods.
     """
     time_delta: float  #: Seconds since last Update
-    scene: BaseScene = None  #: The currently running scene.
+    scene: Scene = None  #: The currently running scene.
 
 
 @dataclass

--- a/ppb/features/loadingscene.py
+++ b/ppb/features/loadingscene.py
@@ -9,12 +9,12 @@ import ppb
 __all__ = 'BaseLoadingScene', 'ProgressBarLoadingScene'
 
 
-class BaseLoadingScene(ppb.BaseScene):
+class BaseLoadingScene(ppb.Scene):
     """
     Handles the basics of a loading screen.
     """
     #: The scene to transition to when loading is complete. May be a type or an instance.
-    next_scene: "ppb.BaseScene"
+    next_scene: "ppb.Scene"
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -1,6 +1,7 @@
 from typing import Callable
 from typing import Iterator
 from typing import Sequence
+import warnings
 
 from ppb.camera import Camera
 from ppb.gomlib import GameObject
@@ -45,3 +46,10 @@ class Scene(GameObject):
         but will be left public for other creative uses.
         """
         return sorted(self, key=lambda s: getattr(s, "layer", 0))
+
+
+class BaseScene(Scene):
+    def __init__(self, *args, **kwargs):
+        # to be removed in 0.14 or 1.0
+        warnings.warn("BaseScene is deprecated, use Scene instead", DeprecationWarning)
+        super().__init__(*args, **kwargs)

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -50,6 +50,5 @@ class Scene(GameObject):
 
 class BaseScene(Scene):
     def __init__(self, *args, **kwargs):
-        # to be removed in 0.14 or 1.0
-        warnings.warn("BaseScene is deprecated, use Scene instead", DeprecationWarning)
+        warnings.warn("BaseScene will be deprecated in 0.14 or 1.0, use Scene instead", DeprecationWarning)
         super().__init__(*args, **kwargs)

--- a/ppb/scenes.py
+++ b/ppb/scenes.py
@@ -6,7 +6,7 @@ from ppb.camera import Camera
 from ppb.gomlib import GameObject
 
 
-class BaseScene(GameObject):
+class Scene(GameObject):
     # Background color, in RGB, each channel is 0-255
     background_color: Sequence[int] = (0, 0, 100)
     camera_class = Camera

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -1,7 +1,7 @@
 """
 Sprites are game objects.
 
-To use a sprite you use :meth:`BaseScene.add <ppb.BaseScene.add>` to add it
+To use a sprite you use :meth:`Scene.add <ppb.Scene.add>` to add it
 to a scene. When contained in an active scene, the engine will call the various
 :mod:`event <ppb.events>` handlers on the sprite.
 

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -4,7 +4,7 @@ import time
 
 import pytest
 
-from ppb import GameEngine, BaseScene
+from ppb import GameEngine, Scene
 import ppb.events
 import ppb.assetlib
 from ppb.assetlib import (
@@ -25,7 +25,7 @@ def clean_assets():
     ppb.assetlib._executor = DelayedThreadExecutor()
 
 
-class AssetTestScene(BaseScene):
+class AssetTestScene(Scene):
     def on_asset_loaded(self, event, signal):
         self.ale = event
         signal(ppb.events.Quit())
@@ -71,7 +71,7 @@ def test_loading(clean_assets):
 
 # def test_loading_root():
 #     a = Asset(...)  # TODO: find a cross-platform target in $VENV/bin
-#     engine = GameEngine(BaseScene, basic_systems=[AssetLoadingSystem])
+#     engine = GameEngine(Scene, basic_systems=[AssetLoadingSystem])
 #     with engine:
 #         engine.start()
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from ppb import GameEngine, BaseScene, Vector
+from ppb import GameEngine, Scene, Vector
 from ppb import events
 from ppb.systemslib import System
 from ppb.systems import Updater
@@ -16,9 +16,9 @@ STOP = False
 
 
 def scenes():
-    yield BaseScene
-    yield BaseScene()
-    yield BaseScene(background_color=(0, 0, 0))
+    yield Scene
+    yield Scene()
+    yield Scene(background_color=(0, 0, 0))
 
 
 @pytest.mark.parametrize("scene", scenes())
@@ -34,7 +34,7 @@ def test_game_engine_with_scene_class():
         "background_color": (69, 69, 69),
         "show_cursor": False
     }
-    with GameEngine(BaseScene, basic_systems=[Quitter], scene_kwargs=props) as ge:
+    with GameEngine(Scene, basic_systems=[Quitter], scene_kwargs=props) as ge:
         ge.run()
 
         assert ge.current_scene.background_color == props["background_color"]
@@ -42,7 +42,7 @@ def test_game_engine_with_scene_class():
 
 
 def test_game_engine_with_instantiated_scene():
-    scene = BaseScene()
+    scene = Scene()
 
     with GameEngine(scene, basic_systems=[Quitter]) as ge:
         ge.run()
@@ -52,14 +52,14 @@ def test_game_engine_with_instantiated_scene():
 
 def test_signal():
 
-    engine = GameEngine(BaseScene, basic_systems=[Quitter])
+    engine = GameEngine(Scene, basic_systems=[Quitter])
     engine.run()
     assert not engine.running
 
 
 def test_signal_once():
 
-    engine = GameEngine(BaseScene, basic_systems=[Quitter])
+    engine = GameEngine(Scene, basic_systems=[Quitter])
     with engine:
         engine.start()
         engine.loop_once()
@@ -79,7 +79,7 @@ def test_contexts():
         def __exit__(self, exc_type, exc_val, exc_tb):
             self.exited = True
 
-    engine = GameEngine(BaseScene, basic_systems=[FakeRenderer, Quitter])
+    engine = GameEngine(Scene, basic_systems=[FakeRenderer, Quitter])
     engine.run()
     for system in engine.children._systems:
         if isinstance(system, FakeRenderer):
@@ -96,7 +96,7 @@ def test_change_scene_event():
     pause_was_run = mock.Mock()
     scene_start_called = mock.Mock()
 
-    class FirstScene(BaseScene):
+    class FirstScene(Scene):
 
         def on_update(self, event, signal):
             signal(events.StartScene(new_scene=SecondScene()))
@@ -105,7 +105,7 @@ def test_change_scene_event():
             assert event.scene is self
             pause_was_run()
 
-    class SecondScene(BaseScene):
+    class SecondScene(Scene):
 
         def on_scene_started(self, event, signal):
             assert event.scene == self
@@ -140,7 +140,7 @@ def test_change_scene_event_no_kwargs():
     pause_was_run = mock.Mock()
     scene_start_called = mock.Mock()
 
-    class FirstScene(BaseScene):
+    class FirstScene(Scene):
 
         def on_update(self, event, signal):
             signal(events.StartScene(new_scene=SecondScene))
@@ -149,7 +149,7 @@ def test_change_scene_event_no_kwargs():
             assert event.scene is self
             pause_was_run()
 
-    class SecondScene(BaseScene):
+    class SecondScene(Scene):
 
         def on_scene_started(self, event, signal):
             assert event.scene == self
@@ -181,7 +181,7 @@ def test_change_scene_event_no_kwargs():
 
 def test_replace_scene_event():
 
-    class FirstScene(BaseScene):
+    class FirstScene(Scene):
 
         def on_update(self, event, signal):
             signal(events.ReplaceScene(new_scene=SecondScene()))
@@ -189,7 +189,7 @@ def test_replace_scene_event():
         def on_scene_stopped(self, event, signal):
             assert event.scene is self
 
-    class SecondScene(BaseScene):
+    class SecondScene(Scene):
 
         def on_scene_started(self, event, signal):
             assert event.scene is self
@@ -219,7 +219,7 @@ def test_stop_scene_event():
 
     test_function = mock.Mock()
 
-    class TestScene(BaseScene):
+    class TestScene(Scene):
 
         def on_update(self, event, signal):
             signal(events.StopScene())
@@ -236,7 +236,7 @@ def test_stop_scene_event():
 
 def test_flush_events():
 
-    ge = GameEngine(BaseScene)
+    ge = GameEngine(Scene)
     ge.signal(events.SceneStopped())
     ge.signal(events.Quit())
 
@@ -269,7 +269,7 @@ def test_event_extension():
         def event_extension(self, event):
             event.test_value = "Red"
 
-    with GameEngine(BaseScene, basic_systems=[TestSystem, Updater, Failer], message="Will only time out.", fail=lambda x: False) as ge:
+    with GameEngine(Scene, basic_systems=[TestSystem, Updater, Failer], message="Will only time out.", fail=lambda x: False) as ge:
         ge.run()
 
 
@@ -282,7 +282,7 @@ def test_extending_all_events():
     class TestEvent:
         pass
 
-    class TestScene(BaseScene):
+    class TestScene(Scene):
 
         def on_update(self, event, signal):
             assert event.test_value == "pursuedpybear"
@@ -318,7 +318,7 @@ def test_idle():
             was_called = True
             signal(events.Quit())
 
-    with GameEngine(BaseScene, basic_systems=[Failer], systems=[TestSystem], fail=lambda x: False, message="Can only time out.") as ge:
+    with GameEngine(Scene, basic_systems=[Failer], systems=[TestSystem], fail=lambda x: False, message="Can only time out.") as ge:
         ge.run()
 
 
@@ -346,7 +346,7 @@ def test_tree():
             nonlocal call_count
             call_count += 1
 
-    with GameEngine(BaseScene, basic_systems=[Failer], systems=[TestSystem], fail=lambda x: False, message="Can only time out.") as ge:
+    with GameEngine(Scene, basic_systems=[Failer], systems=[TestSystem], fail=lambda x: False, message="Can only time out.") as ge:
         ge.run()
 
     assert call_count == 7

--- a/tests/test_layering.py
+++ b/tests/test_layering.py
@@ -16,7 +16,7 @@ class NoLayer:
 
 def test_layering_attribute():
 
-    class LayeredScene(scenes.BaseScene):
+    class LayeredScene(scenes.Scene):
 
         def __init__(self):
             super().__init__()
@@ -35,7 +35,7 @@ def test_change_layer():
     test_sprite = LayeredSprite(0)
     ones = tuple(LayeredSprite(1) for _ in range(3))
 
-    scene = scenes.BaseScene()
+    scene = scenes.Scene()
     scene.add(test_sprite)
     for sprite in ones:
         scene.add(sprite)
@@ -50,7 +50,7 @@ def test_change_layer():
 def test_layering_without_layer_attribute():
 
     test_sprite = NoLayer()
-    scene = scenes.BaseScene()
+    scene = scenes.Scene()
 
     scene.add(test_sprite)
     for x in range(1, 6):

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -1,10 +1,8 @@
-from unittest.mock import Mock
-
 from pytest import fixture
-from pytest import mark
-from pytest import raises
+from pytest import deprecated_call
 
 from ppb.scenes import Scene
+from ppb.scenes import BaseScene
 from ppb.camera import Camera
 
 
@@ -33,3 +31,8 @@ def test_class_attrs():
 
     scene = BackgroundScene(background_color=(2, 4, 0))
     assert scene.background_color == (2, 4, 0)
+
+
+def test_base_scene_deprecated():
+    with deprecated_call():
+        BaseScene()

--- a/tests/test_scenes.py
+++ b/tests/test_scenes.py
@@ -4,13 +4,13 @@ from pytest import fixture
 from pytest import mark
 from pytest import raises
 
-from ppb.scenes import BaseScene
+from ppb.scenes import Scene
 from ppb.camera import Camera
 
 
 @fixture()
 def scene():
-    return BaseScene()
+    return Scene()
 
 
 def test_main_camera(scene):
@@ -25,7 +25,7 @@ def test_main_camera(scene):
 
 
 def test_class_attrs():
-    class BackgroundScene(BaseScene):
+    class BackgroundScene(Scene):
         background_color = (0, 4, 2)
 
     scene = BackgroundScene()

--- a/tests/test_twophase.py
+++ b/tests/test_twophase.py
@@ -1,4 +1,4 @@
-from ppb import GameEngine, BaseScene
+from ppb import GameEngine, Scene
 from ppb.testutils import Quitter
 from ppb.events import Update
 from ppb.features.twophase import TwoPhaseMixin, TwoPhaseSystem, Commit
@@ -7,7 +7,7 @@ from ppb.features.twophase import TwoPhaseMixin, TwoPhaseSystem, Commit
 def test_twophase():
     events = []
 
-    class TestScene(BaseScene, TwoPhaseMixin):
+    class TestScene(Scene, TwoPhaseMixin):
         flag = False
 
         def on_update(self, event, signal):

--- a/viztests/loading.py
+++ b/viztests/loading.py
@@ -21,7 +21,7 @@ class DelayedImage(ppb.Image):
         return super().background_parse(data)
 
 
-class Quitter(ppb.BaseScene):
+class Quitter(ppb.Scene):
     loop_count = 1
 
     def __init__(self, **kwargs):

--- a/viztests/show_cursor.py
+++ b/viztests/show_cursor.py
@@ -16,7 +16,7 @@ no_cursor = "No cursor should be visible."
 cursor = "Cursor should be visible."
 
 
-class RootScene(ppb.BaseScene):
+class RootScene(ppb.Scene):
     cursor = [no_cursor, cursor]
     _continue = "Click to continue."
     click_event = ppb.events.StopScene()

--- a/viztests/sound_flooded_channels.py
+++ b/viztests/sound_flooded_channels.py
@@ -7,7 +7,7 @@ NOTE: Does not open a window.
 import ppb
 
 
-class Scene(ppb.BaseScene):
+class Scene(ppb.Scene):
     sound = ppb.Sound("laser1.ogg")
     running = 0
     lifespan = 4

--- a/viztests/soundonly.py
+++ b/viztests/soundonly.py
@@ -6,7 +6,7 @@ NOTE: Does not open a window.
 import ppb
 
 
-class Scene(ppb.BaseScene):
+class Scene(ppb.Scene):
     sound = ppb.Sound("laser1.ogg")
     running = 0
     lifespan = 2

--- a/viztests/text.py
+++ b/viztests/text.py
@@ -13,7 +13,7 @@ def hsv2rgb(h, s, v):
     return list(map(int, colorsys.hsv_to_rgb(h, s, v)))
 
 
-class TextScene(ppb.BaseScene):
+class TextScene(ppb.Scene):
     elapsed = 0
 
     def on_scene_started(self, event, signal):


### PR DESCRIPTION
Addresses https://github.com/ppb/pursuedpybear/issues/569

- Renamed `ppb.BaseScene` to `Scene` in scenes.py (using PyCharm refactor)
- Added child class of `Scene` called `BaseScene` with a deprecation warning (and a comment "to be removed in 0.14 or 1.0")
- Import `Scene` into `__init__.py`
- Updates tests to use `ppb.Scene`
- Added test to confirm BaseScene raises deprecation warning 
- For sanity check, ran `python -m viztests` after installing local version ppb