### PR TITLE
Add default KeyboardMovementSprite

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -42,8 +42,9 @@ Halle Jones|HJones@aliacy.com||
 [Bernard Sanders](https://github.com/bernardthered) | | [@BernardCBolt](https://twitter.com/BernardCBolt)
 [Morisa Manzella](https://github.com/mgmanzella) | |
 [Mark J Cameron](https://github.come/kcalmwinds) |  | [LuminariWeekly](https://twitter.com/LuminariWeekly) |
-[Laura G. Funderburk](https://github.com/lfunderburk) | | [@lgfunderburk](https://twitter.com/lgfunderburk)| 
+[Laura G. Funderburk](https://github.com/lfunderburk) | | [@lgfunderburk](https://twitter.com/lgfunderburk)|
 [Mark Boer](https://github.com/mark-boer) | |
 [Anthony Plunkett](https://github.com/doobeh) | |
 [Mateus Denucci Garcia Seabra Resende](https://github.com/MateusDenucci) | |
 [Victor Hart](https://github.com/vicohart) | [vicohart@gmail.com](vicohart@gmail.com) |
+[Aaron Mak](https://github.com/aaronmak) | [im@arnmk.com](mailto:im@arnmk.com) |

--- a/docs/reference/features/default_sprites.rst
+++ b/docs/reference/features/default_sprites.rst
@@ -1,0 +1,16 @@
+Default Sprites
+===============
+.. py:module:: ppb.features.default_sprites
+
+Default sprites for common use cases with sane defaults.
+
+
+Reference
+~~~~~~~~~
+
+.. autoclass:: ppb.features.default_sprites.TargetSprite
+   :members:
+
+
+.. autoclass:: ppb.features.default_sprites.KeyboardMovementSprite
+   :members:

--- a/ppb/features/default_sprites.py
+++ b/ppb/features/default_sprites.py
@@ -1,13 +1,14 @@
 """
 Theme: sprites with common default behaviours (motion)
 
-Types of motion include: relative to the motion of other sprites, moving 
-towards another object. 
+Types of motion include: relative to the motion of other sprites, moving
+towards another object.
 
 """
 
 import ppb
 import math
+from typing import Dict
 
 
 class TargetSprite(ppb.Sprite):
@@ -58,3 +59,106 @@ class TargetSprite(ppb.Sprite):
         remaining = decay_rate ** time_delta
         decay_amount = 1. - remaining
         return decay_amount
+
+
+ARROW_KEYS = {
+    "up": ppb.keycodes.Up,
+    "left": ppb.keycodes.Left,
+    "down": ppb.keycodes.Down,
+    "right": ppb.keycodes.Right,
+}
+
+WASD_KEYS = {
+    "up": ppb.keycodes.W,
+    "left": ppb.keycodes.A,
+    "down": ppb.keycodes.S,
+    "right": ppb.keycodes.D,
+}
+
+
+class KeyboardMovementSprite(ppb.Sprite):
+    """
+    Sprite that moves with keyboard movement keys.
+
+
+    Example: ::
+
+        player = KeyboardMovementSprite()
+
+        def setup(scene):
+            scene.add(player)
+
+        ppb.run(setup=setup)
+
+    :param initial_speed: The speed per second when the first of subsequent keypresses are made.
+    :param acceleration: The increase in speed for a repeated key press.
+    :param friction: The rate of decrease in speed.
+    :param max_speed: Maximum speed per second that the sprite can travel in a specific direction.
+    :param direction_keys: Configuration for mapping direction to keys. Requires a dictionary with
+        the keys `up`, `left`, `down`, right` and value of type `ppb.keycodes.KeyCode`.
+    """
+
+    initial_speed: float = 1.0
+    acceleration: float = 0.2
+    friction: float = 0.8
+    max_speed: float = math.inf
+    direction_keys: Dict[str, ppb.keycodes.KeyCode] = ARROW_KEYS
+    speed: ppb.Vector = ppb.Vector(0, 0)
+
+    def on_update(self, update_event, signal):
+        self._validate()
+        self._limit_speed()
+        self._stop_if_slow()
+        self._slow_down(update_event.time_delta)
+
+        self.position += self.speed * update_event.time_delta
+
+    def on_key_pressed(self, key_event: ppb.events.KeyPressed, signal):
+        self._adjust_speed(key_event)
+
+    def _validate(self):
+        if self.friction > 1 or self.friction < 0:
+            raise ValueError(f"{type(self).__name__} friction must be between 0 and 1.")
+
+        if self.initial_speed <= 0:
+            raise ValueError(f"{type(self).__name__} initial speed must be a positive value.")
+
+        if self.acceleration < 0:
+            raise ValueError(f"{type(self).__name__} acceleration must be more than or equals to 0.")
+
+        if self.max_speed <= 0:
+            raise ValueError(f"{type(self).__name__} max speed must be a positive value.")
+
+    def _slow_down(self, time_delta: float):
+        self.speed = self.speed * (1 - self.friction) ** time_delta
+
+    def _stop_if_slow(self):
+        if self.speed.length < ppb.Vector(0.5, 0.5).length:
+            self._reset_speed()
+
+    def _reset_speed(self):
+        self.speed = ppb.Vector(0, 0)
+
+    def _adjust_speed(self, key_event):
+        if self.speed.length > self.initial_speed:
+            magnitude = (1 + self.acceleration) * self.initial_speed
+        else:
+            magnitude = self.initial_speed
+
+        if key_event.key == self.direction_keys["left"]:
+            change = ppb.directions.Left
+        elif key_event.key == self.direction_keys["right"]:
+            change = ppb.directions.Right
+        elif key_event.key == self.direction_keys["up"]:
+            change = ppb.directions.Up
+        elif key_event.key == self.direction_keys["down"]:
+            change = ppb.directions.Down
+        else:
+            change = None
+
+        if change:
+            self.speed += change.scale_to(magnitude)
+
+    def _limit_speed(self):
+        if self.speed.length > self.max_speed:
+            self.speed = self.speed.scale_to(self.max_speed)

--- a/tests/test_default_sprites.py
+++ b/tests/test_default_sprites.py
@@ -1,7 +1,7 @@
-import unittest
 import ppb
+import pytest
 from ppb import Vector
-from ppb.features.default_sprites import TargetSprite
+from ppb.features.default_sprites import TargetSprite, KeyboardMovementSprite, WASD_KEYS
 
 
 def test_target_sprite_linear():
@@ -42,3 +42,103 @@ def test_target_sprite_min_speed():
     target_sprite.on_update(ppb.events.Update(1.0), lambda x: None)
 
     assert target_sprite.position.isclose((-1.2, -1.6))
+
+
+class TestKeyboardMovementSprite:
+
+    def test_speed(self):
+        sprite = KeyboardMovementSprite()
+        sprite.speed = Vector(2, 0)
+        sprite.friction = 0
+        sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+        assert sprite.position.isclose((2, 0))
+
+    def test_max_speed(self):
+        sprite = KeyboardMovementSprite()
+        sprite.speed = Vector(10, 0)
+        sprite.max_speed = 1.0
+        sprite.friction = 0
+        sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+        assert sprite.position.isclose((1, 0))
+
+    def test_friction(self):
+        sprite = KeyboardMovementSprite()
+        sprite.speed = Vector(2, 0)
+        sprite.friction = 0.5
+        sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+        assert sprite.position.isclose((1, 0))
+
+    def test_stop_if_slow(self):
+        sprite = KeyboardMovementSprite()
+        sprite.speed = Vector(0, 0.5)
+        sprite.friction = 0
+        sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+        assert sprite.position.isclose((0, 0))
+
+    @pytest.mark.parametrize("friction", [-1, -0.1, 1.1, 2])
+    def test_friction_error(self, friction):
+        with pytest.raises(ValueError):
+            sprite = KeyboardMovementSprite()
+            sprite.friction = friction
+            sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+    @pytest.mark.parametrize("initial_speed", [-1, 0])
+    def test_initial_speed_error(self, initial_speed):
+        with pytest.raises(ValueError):
+            sprite = KeyboardMovementSprite()
+            sprite.initial_speed = initial_speed
+            sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+    @pytest.mark.parametrize("acceleration", [-0.1, -1])
+    def test_initial_speed_error(self, acceleration):
+        with pytest.raises(ValueError):
+            sprite = KeyboardMovementSprite()
+            sprite.acceleration = acceleration
+            sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+    @pytest.mark.parametrize("max_speed", [-0.1, -1, 0])
+    def test_initial_speed_error(self, max_speed):
+        with pytest.raises(ValueError):
+            sprite = KeyboardMovementSprite()
+            sprite.max_speed = max_speed
+            sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+    @pytest.mark.parametrize(
+        "keypress,expected",
+        [
+            (ppb.keycodes.Up, (0, 1)),
+            (ppb.keycodes.Down, (0, -1)),
+            (ppb.keycodes.Left, (-1, 0)),
+            (ppb.keycodes.Right, (1, 0)),
+        ]
+    )
+    def test_basic_keypress(self, keypress, expected):
+        sprite = KeyboardMovementSprite()
+        sprite.friction = 0
+        sprite.on_key_pressed(ppb.events.KeyPressed(key=keypress, mods=set()), signal=None)
+        sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+        assert sprite.position.isclose(expected)
+
+    @pytest.mark.parametrize(
+        "keypress,expected",
+        [
+            (ppb.keycodes.W, (0, 1)),
+            (ppb.keycodes.S, (0, -1)),
+            (ppb.keycodes.A, (-1, 0)),
+            (ppb.keycodes.D, (1, 0)),
+        ]
+    )
+    def test_wasd_keypress(self, keypress, expected):
+        sprite = KeyboardMovementSprite()
+        sprite.direction_keys = WASD_KEYS
+        sprite.friction = 0
+        print(sprite.direction_keys)
+        sprite.on_key_pressed(ppb.events.KeyPressed(key=keypress, mods=set()), signal=None)
+        sprite.on_update(ppb.events.Update(1.0), lambda x: None)
+
+        assert sprite.position.isclose(expected)


### PR DESCRIPTION
For https://github.com/ppb/pursuedpybear/issues/384

Create a KeyboardMovementSprite with sane defaults

Each key press would send the sprite in the appropriate direction with a
default deceleration

Also create basic classes for the user to change the keyboard direction
keys