### PR TITLE
Nix the last of the posers

### DIFF
--- a/examples/keyboard_and_mouse_controls/targets.py
+++ b/examples/keyboard_and_mouse_controls/targets.py
@@ -43,7 +43,7 @@ class Player(MoverMixin, ppb.Sprite):
     def _fire_bullet(self, scene, signal):
         signal(PlaySound(self.fire_sound))
         scene.add(
-            Bullet(pos=self.position),
+            Bullet(position=self.position),
             tags=['bullet']
         )
 
@@ -77,11 +77,11 @@ class GameScene(ppb.Scene):
         super().__init__(*p, **kw)
 
         # Set up sprites
-        self.add(Player(pos=Vector(0, 0)), tags=['player'])
+        self.add(Player(position=Vector(0, 0)), tags=['player'])
 
         # 5 targets in x = -3.75 -> 3.75, with margin
         for x in (-3, -1.5, 0, 1.5, 3):
-            self.add(Target(pos=Vector(x, 1.875)), tags=['target'])
+            self.add(Target(position=Vector(x, 1.875)), tags=['target'])
 
 
 if __name__ == "__main__":

--- a/viztests/loading.py
+++ b/viztests/loading.py
@@ -54,7 +54,7 @@ class LoadingScene(ProgressBarLoadingScene):
 
     def get_progress_sprites(self):
         for x in range(-2, 3):
-            yield ppb.Sprite(pos=ppb.Vector(x, 0))
+            yield ppb.Sprite(position=ppb.Vector(x, 0))
 
 
 ppb.run(starting_scene=LoadingScene)


### PR DESCRIPTION
There was some remaining usages of `pos` in various corners of the codebase. Fix that.