### PR TITLE
Fixed references to Ellipse, free(), and load() in Asset System reference

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -49,4 +49,4 @@ Halle Jones|HJones@aliacy.com||
 [Victor Hart](https://github.com/vicohart) | [vicohart@gmail.com](vicohart@gmail.com) |
 [nilamo](https://github.com/nilamo) | [7nilamo@gmail.com](7nilamo@gmail.com) | 
 [Abhijeet](https://github.com/abhijeetgupto) |[abhigupta7b@gmail.com](abhigupta7b@gmail.com) | [@abhijeetgupto](https://twitter.com/abhijeetgupto)|
-[Andy Tran](https://github.com/tran-dy) |
+[Andy Tran](https://github.com/tran-dy) | | |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,3 +48,4 @@ Halle Jones|HJones@aliacy.com||
 [Mateus Denucci Garcia Seabra Resende](https://github.com/MateusDenucci) | |
 [Victor Hart](https://github.com/vicohart) | [vicohart@gmail.com](vicohart@gmail.com) |
 [nilamo](https://github.com/nilamo) | [7nilamo@gmail.com](7nilamo@gmail.com) | 
+[Andy Tran](https://github.com/tran-dy) |

--- a/docs/discussion/assets.rst
+++ b/docs/discussion/assets.rst
@@ -23,7 +23,7 @@ Out of this, we define a few high-level concepts:
 
 * Asset: Some kind of way data is loaded & parsed. Usually the result is some internal engine data type.
 * Real or File Asset: Loads data from the VFS (such as :py:class:`ppb.Image`)
-* Virtual Asset: Synthesizes data from nothing (such as :py:class:`ppb.assets.Circle`)
+* Virtual Asset: Synthesizes data from nothing (such as :py:class:`ppb.Ellipse`)
 * Proxy Asset: Wraps other asset types (such as :py:class:`ppb.features.animation.Animation`)
 
 The idea is that the place where the asset is used does not care what kind of asset is used, only that it produces the right kind of data--nothing in the world can make the renderer accept a :py:class:`ppb.Sound`.
@@ -64,4 +64,4 @@ Proxy Assets
 
 Proxy assets are simply assets that wrap other, more concrete assets. One example of this is :py:mod:`ppb.features.animation`, where :py:class:`Animation <ppb.features.animation>` wraps multiple :py:class:`Image <ppb.Image>` instances.
 
-Writing your own proxy asset just means returning the results of your inner asset's :py:meth:`load()` from your own.
+Writing your own proxy asset just means returning the results of your inner asset's :py:meth:`Asset.load()` from your own.

--- a/docs/reference/assets.rst
+++ b/docs/reference/assets.rst
@@ -34,9 +34,12 @@ system and the data logistics.
 
         Called in the background thread.
 
+    .. automethod:: free()
+
     .. automethod:: load(timeout: float = None)
 
     .. automethod:: is_loaded()
+
 
 
 Subclassing


### PR DESCRIPTION
Fixes for issue #607 

Updated the reference to Ellipse and load().
Added the free() method to the Asset reference page to fix the free() hyperlink.