### PR TITLE
Deprecation warning for python3.6

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -48,3 +48,4 @@ Halle Jones|HJones@aliacy.com||
 [Mateus Denucci Garcia Seabra Resende](https://github.com/MateusDenucci) | |
 [Victor Hart](https://github.com/vicohart) | [vicohart@gmail.com](vicohart@gmail.com) |
 [nilamo](https://github.com/nilamo) | [7nilamo@gmail.com](7nilamo@gmail.com) | 
+[Michael duBois](https://github.com/MichaelCduBois) |  | 

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -94,8 +94,8 @@ def _validate_python_support(required_version='3.7', ppb_release='2.0',
                               f"Python {version_info[0]}.{version_info[1]} " \
                               f"once released around {release_date}. Please " \
                               f"update to Python {required_version} or newer."
-        logger = logging.getLogger(__name__)
-        logger.warning(f"Deprecation Warning: {deprecation_message}")
+        warnings.filterwarnings('default')
+        warnings.warn(deprecation_message, DeprecationWarning)
 
 
 def run(setup: Callable[[Scene], None] = None, *, log_level=logging.WARNING,

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -84,7 +84,7 @@ def _validate_python_support(required_version='3.7', ppb_release='2.0',
     :param required_version: Minimum Python Version Supported by PPB
     :type required_version: str
     :param ppb_release: PPB release version deprecation will occur
-    :type ppb_relase: str
+    :type ppb_release: str
     :param release_date: Estimated release month for PPB Version
     :type release_date: str
     """

--- a/ppb/__init__.py
+++ b/ppb/__init__.py
@@ -30,6 +30,7 @@ Exports:
 """
 
 import logging
+from sys import version_info
 from typing import Callable
 
 from ppb import directions
@@ -71,6 +72,30 @@ def _make_kwargs(setup, title, engine_opts):
         **engine_opts
     }
     return kwargs
+
+
+def _validate_python_support(required_version='3.7', ppb_release='2.0',
+                             release_date='June 2022'):
+    """
+    Verifies Supported Python Version.
+
+    This function verifies ppb is running on a supported Python version.
+
+    :param required_version: Minimum Python Version Supported by PPB
+    :type required_version: str
+    :param ppb_release: PPB release version deprecation will occur
+    :type ppb_relase: str
+    :param release_date: Estimated release month for PPB Version
+    :type release_date: str
+    """
+    # Creates (Major, Minor) version tuples for comparisson
+    if version_info[0:2] <= tuple(map(int, required_version.split('.'))):
+        deprecation_message = f"PPB v{ppb_release} will no longer support "\
+                              f"Python {version_info[0]}.{version_info[1]} " \
+                              f"once released around {release_date}. Please " \
+                              f"update to Python {required_version} or newer."
+        logger = logging.getLogger(__name__)
+        logger.warning(f"Deprecation Warning: {deprecation_message}")
 
 
 def run(setup: Callable[[Scene], None] = None, *, log_level=logging.WARNING,
@@ -121,6 +146,8 @@ def run(setup: Callable[[Scene], None] = None, *, log_level=logging.WARNING,
        :class:`~ppb.engine.GameEngine`.
     """
     logging.basicConfig(level=log_level)
+
+    _validate_python_support()
 
     with make_engine(setup, starting_scene=starting_scene, title=title, **engine_opts) as eng:
         eng.run()


### PR DESCRIPTION
This is the feature for #636 

If the user is running Python 3.6 a deprecation warning is logged.