### PR TITLE
Add helpful error when translate_point_to_screen fails due to AttributeError

### DIFF
--- a/ppb/camera.py
+++ b/ppb/camera.py
@@ -163,7 +163,11 @@ class Camera(RectangleShapeMixin, GameObject):
         :return: A vector in pixels.
         :rtype: Vector
         """
-        return Vector(point.x - self.left, self.top - point.y) * self.pixel_ratio
+
+        try:
+          return Vector(point.x - self.left, self.top - point.y) * self.pixel_ratio
+        except AttributeError as error:
+          raise TypeError("Expected Vector")
 
     def translate_point_to_game_space(self, point: Vector) -> Vector:
         """

--- a/ppb/camera.py
+++ b/ppb/camera.py
@@ -167,7 +167,7 @@ class Camera(RectangleShapeMixin, GameObject):
         try:
           return Vector(point.x - self.left, self.top - point.y) * self.pixel_ratio
         except AttributeError as error:
-          raise TypeError("Expected Vector")
+          raise TypeError(f"Expected Vector got {type(point).__name__}: {point!r}")
 
     def translate_point_to_game_space(self, point: Vector) -> Vector:
         """

--- a/ppb/systems/renderer.py
+++ b/ppb/systems/renderer.py
@@ -311,7 +311,18 @@ class Renderer(SdlSubSystem):
 
         win_w, win_h = self.target_resolution(img_w.value, img_h.value, obj_w, obj_h, camera.pixel_ratio)
 
-        center = camera.translate_point_to_screen(game_object.position)
+        try:
+            center = camera.translate_point_to_screen(game_object.position)
+        except TypeError as error:
+            raise TypeError(f"""{type(game_object).__name__}.position was set to a tuple: 
+
+            (number, number)
+
+            Expected a vector:
+
+            Vector(number, number)
+            """)
+
         dest_rect = SDL_Rect(
             x=int(center.x - win_w / 2),
             y=int(center.y - win_h / 2),

--- a/ppb/systems/renderer.py
+++ b/ppb/systems/renderer.py
@@ -321,7 +321,7 @@ class Renderer(SdlSubSystem):
             Expected a vector:
 
             Vector(number, number)
-            """)
+            """) from error
 
         dest_rect = SDL_Rect(
             x=int(center.x - win_w / 2),

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -101,9 +101,19 @@ def test_camera_point_is_visible(camera, position, point, expect):
     [Vector(0, 0), Vector(4, -3), Vector(720, 540)],
     [Vector(0, 0), Vector(-6, 4), Vector(-80, -20)]
 ])
-def test_camera_translate_point_to_screen(camera, position, point, expected):
+def test_camera_translate_point_to_screen_valid_vectors(camera, position, point, expected):
     camera.position = position
     assert camera.translate_point_to_screen(point) == expected
+
+@pytest.mark.parametrize("point", [
+  [(1.0, 1.0)],
+  [{"x": 1.0, "y": 1.0}],
+  [(1000000.0, -1.0)],
+  [[1.0, 1.0]],
+])
+def test_camera_translate_point_to_screen_invalid_vectors(camera, point):
+    with pytest.raises(TypeError) as excinfo:
+        camera.translate_point_to_screen(point)
 
 
 @pytest.mark.parametrize("position, point, expected", [


### PR DESCRIPTION
Add detailed error info to camera.translate_point_to_screen(), which is helpful for tests

Add detailed error info to renderer.compute_rectangles(), which is helpful for when users use a VectorLike instead of a Vector

Fixes #612