### PR TITLE
Fixes list dist uploads.

### DIFF
--- a/.ci/upload.xsh
+++ b/.ci/upload.xsh
@@ -35,7 +35,7 @@ with tempfile.TemporaryDirectory() as td:
         # print(f"Found {len(nl)} files from build:", *nl)
         zf.extractall()
 
-    dists = [f for f in pg`**` if '+' not in f.name and f.is_file()]
+    dists = [f for f in pg`**` if '+' not in f.name and 'examples.zip' not in f.name and f.is_file()]
 
     if not dists:
         print("No uploadable dists found, skipping upload")

--- a/.ci/upload.xsh
+++ b/.ci/upload.xsh
@@ -35,7 +35,7 @@ with tempfile.TemporaryDirectory() as td:
         # print(f"Found {len(nl)} files from build:", *nl)
         zf.extractall()
 
-    dists = [f for f in pg`**` if '+' not in f.name and 'examples.zip' not in f.name and f.is_file()]
+    dists = [f for f in pg`**` if '+' not in f.name and f.name != 'examples.zip' and f.is_file()]
 
     if not dists:
         print("No uploadable dists found, skipping upload")


### PR DESCRIPTION
Prevents `examples.zip` from being included in `dists` 

Tested the comprehension on a xonsh container:

```
<user>@8f257c1bbfc7 ~/tmp # touch dist1
<user>@8f257c1bbfc7 ~/tmp # touch dist2
<user>@8f257c1bbfc7 ~/tmp # touch dist3
<user>@8f257c1bbfc7 ~/tmp # touch examples.zip
<user>@8f257c1bbfc7 ~/tmp # dists = [f for f in pg`**` if '+' not in f.name and 'examples.zip' not in f.name and f.is_fi
le()]
<user>@8f257c1bbfc7 ~/tmp # dists
[PosixPath('dist1'), PosixPath('dist2'), PosixPath('dist3')]
```