### PR TITLE
setup.py: Move remaining options to declarative config, delete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,7 @@ requires = ["setuptools>=30.3.0", "wheel", "setuptools_scm"]
 
 # Actually tell PEP517 tools to call setuptools
 build-backend = "setuptools.build_meta"
+
+
+[tool.setuptools_scm]
+local_scheme = "dirty-tag"

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,5 @@ install_requires = file: requirements.txt
 tests_requires = file: requirements-tests.txt
 
 python_requires = >= 3.6
+
+use_scm_version = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,5 +36,7 @@ setup_requires =
     pytest-runner
     wheel
     setuptools_scm
+install_requires = file: requirements.txt
+tests_requires = file: requirements-tests.txt
 
 python_requires = >= 3.6

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python3
-from setuptools import setup
-
-
-# See setup.cfg for the actual configuration.
-setup()

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,4 @@ from setuptools import setup
 
 
 # See setup.cfg for the actual configuration.
-setup(
-    use_scm_version={
-        'local_scheme': 'dirty-tag',
-    },
-)
+setup()

--- a/setup.py
+++ b/setup.py
@@ -2,22 +2,9 @@
 from setuptools import setup
 
 
-def requirements(section=None):
-    """Helper for loading dependencies from requirements files."""
-    if section is None:
-        filename = "requirements.txt"
-    else:
-        filename = f"requirements-{section}.txt"
-
-    with open(filename) as file:
-        return [line.strip() for line in file]
-
-
 # See setup.cfg for the actual configuration.
 setup(
     use_scm_version={
         'local_scheme': 'dirty-tag',
     },
-    install_requires=requirements(),
-    tests_require=requirements('tests'),
 )


### PR DESCRIPTION
- Move requirements to `setup.cfg`
- Move `setuptools_scm` configuration to the declarative files
- Remove `setup.py`
