### PR TITLE
set dimensions for missing image

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -57,3 +57,4 @@ Halle Jones|HJones@aliacy.com||
 [Avarice M](https://github.com/avarice-m) | | |
 [Jami Schwarzwalder](https://github.com/jschwarzwalder) | |
 [Jill Slind](https://github.com/jillslind) | [jill.slind@gmail.com](jill.slind@gmail.com) | |
+[David Lord](https://github.com/davidism) | |

--- a/ppb/sprites.py
+++ b/ppb/sprites.py
@@ -442,3 +442,10 @@ class RectangleSprite(RectangleShapeMixin, RenderableMixin, RotatableMixin, Base
     with the mixins :class:`RotatableMixin`, :class:`RenderableMixin`, and
     :class:`RectangleShapeMixin`.
     """
+
+    def __image__(self):
+        image = super().__image__()
+        # Override the dimensions of the ``Image`` so that the missing shape
+        # matches this sprite's dimensions.
+        image._file_missing_dimensions = (self.width, self.height)
+        return image

--- a/ppb/systems/renderer.py
+++ b/ppb/systems/renderer.py
@@ -75,6 +75,11 @@ class Image(assets.Asset):
     not_found_message = "This may not be a problem, you can stop this warning by explicitly " \
                         "setting the `image` attribute on your Sprite subclass to an Image object."
 
+    _file_missing_dimensions = (1, 1)
+    """``RectangleSprite.__image__`` will override this to use its width and
+    height instead of the default, so that it is not a square shape.
+    """
+
     def background_parse(self, data):
         file = rw_from_object(io.BytesIO(data))
         # ^^^^ is a pure-python emulation, does not need cleanup.
@@ -91,7 +96,7 @@ class Image(assets.Asset):
         return surface
 
     def file_missing(self):
-        width = height = 70  # Pixels, arbitrary
+        width, height = self._file_missing_dimensions  # Pixels, arbitrary
         surface = sdl_call(
             SDL_CreateRGBSurface, 0, width, height, 32, 0, 0, 0, 0,
             _check_error=lambda rv: not rv


### PR DESCRIPTION
When a RectangleSprite falls back to rendering a default shape instead
of an image, use its dimensions rather than a default square.

This adds a private `_file_missing_dimensions` tuple to `Image`, which defaults to `(1, 1)`. `RectangleSprite.__image__` sets this to its dimensions so that the default shape is a rectangle instead of a square.

fixes #691 

```
import ppb


class Platform(ppb.RectangleSprite):
    pass


class Player(ppb.Sprite):
    pass


def setup(scene):
    platform = Platform(width=3, height=1, position=ppb.Vector(0, -5))
    scene.add(platform)
    player = Player()
    scene.add(player)


ppb.run(setup)
```

<img width="912" alt="Screenshot 2024-04-08 at 09 57 41" src="https://github.com/ppb/pursuedpybear/assets/1242887/5a900a11-948b-491d-aa59-93102a6e7f14">