### PR TITLE
Added sprite that uses mouse as a target

### DIFF
--- a/ppb/features/default_sprites.py
+++ b/ppb/features/default_sprites.py
@@ -11,6 +11,7 @@ import math
 from ppb import keycodes
 from ppb.events import KeyPressed, KeyReleased
 from dataclasses import dataclass
+import ppb.events as events
 
 
 class TargetSprite(ppb.Sprite):
@@ -131,3 +132,17 @@ class KeyBoardMovementSprite(ppb.Sprite):
             self.direction += ppb.Vector(0, -1)
         if key_event.key == self.key_bindings.down:
             self.direction += ppb.Vector(0, 1)
+
+class MouseCursorSprite(ppb.Sprite):
+    """Sprite that acts like a mouse cursor
+    """
+    def on_mouse_motion(self, event: events.MouseMotion, signal):
+        self.position = event.position
+
+class MouseTargetSprite(TargetSprite):
+    """Sprite that treats your mouse as a moving target
+    """
+    def on_mouse_motion(self, event: events.MouseMotion, signal):
+        self.target = event.position
+
+

--- a/ppb/features/default_sprites.py
+++ b/ppb/features/default_sprites.py
@@ -136,8 +136,16 @@ class KeyBoardMovementSprite(ppb.Sprite):
 class MouseCursorSprite(ppb.Sprite):
     """Sprite that acts like a mouse cursor
     """
+    def __init__(self, **props):
+        super().__init__(**props)
+        # we set the size to zero otherwise the sprite appears to teleport
+        # we store the initial size so we can put it back later, so the size parameter works as it should 
+        self._initial_size = self.size 
+        self.size = 0
+
     def on_mouse_motion(self, event: events.MouseMotion, signal):
         self.position = event.position
+        self.size = self._initial_size
 
 class MouseTargetSprite(TargetSprite):
     """Sprite that treats your mouse as a moving target

--- a/ppb/features/default_sprites.py
+++ b/ppb/features/default_sprites.py
@@ -133,22 +133,12 @@ class KeyBoardMovementSprite(ppb.Sprite):
         if key_event.key == self.key_bindings.down:
             self.direction += ppb.Vector(0, 1)
 
-class MouseCursorSprite(ppb.Sprite):
-    """Sprite that acts like a mouse cursor
-    """
-    def __init__(self, **props):
-        super().__init__(**props)
-        # we set the size to zero otherwise the sprite appears to teleport
-        # we store the initial size so we can put it back later, so the size parameter works as it should 
-        self._initial_size = self.size 
-        self.size = 0
-
-    def on_mouse_motion(self, event: events.MouseMotion, signal):
-        self.position = event.position
-        self.size = self._initial_size
 
 class MouseTargetSprite(TargetSprite):
-    """Sprite that treats your mouse as a moving target
+    """Sprite that treats your mouse as a moving target.
+
+    :param speed: Distance per second that the sprite travels with linear motion. 
+    If you set the speed to a high number (eg 100) then the sprite can act as a cursor. And if you set it to a lower number then it will chase the mouse menacingly 
     """
     def on_mouse_motion(self, event: events.MouseMotion, signal):
         self.target = event.position

--- a/tests/test_default_sprites.py
+++ b/tests/test_default_sprites.py
@@ -4,7 +4,10 @@ from ppb.features.default_sprites import (
     TargetSprite,
     wasd_direction_key_bindings,
     KeyBoardMovementSprite,
+    MouseCursorSprite,
+    MouseTargetSprite
 )
+import ppb.events as events
 
 
 def test_target_sprite_linear():
@@ -134,3 +137,22 @@ def test_keyboard_movement_sprite_move_down_left_wasd():
 
     assert keyboard_sprite.direction.isclose((-1, -1))
     assert keyboard_sprite.position.isclose((-1, -1))
+
+
+def test_mouse_target_sprite():
+    sprite = MouseTargetSprite()
+
+    mouse_position = Vector(123,456)
+    sprite.on_mouse_motion(events.MouseMotion(mouse_position,Vector(0,0),buttons=[]), lambda x:None)
+    assert sprite.target == mouse_position
+
+
+def test_mouse_cursor_sprite():
+    sprite = MouseCursorSprite()
+
+    mouse_position = Vector(123,456)
+    sprite.on_mouse_motion(events.MouseMotion(mouse_position,Vector(0,0),buttons=[]), lambda x:None)
+    assert sprite.position == mouse_position
+
+
+    

--- a/tests/test_default_sprites.py
+++ b/tests/test_default_sprites.py
@@ -4,7 +4,6 @@ from ppb.features.default_sprites import (
     TargetSprite,
     wasd_direction_key_bindings,
     KeyBoardMovementSprite,
-    MouseCursorSprite,
     MouseTargetSprite
 )
 import ppb.events as events
@@ -147,22 +146,3 @@ def test_mouse_target_sprite():
     assert sprite.target == mouse_position
 
 
-def test_mouse_cursor_sprite_movement():
-    sprite = MouseCursorSprite()
-
-    mouse_position = Vector(123,456)
-    sprite.on_mouse_motion(events.MouseMotion(mouse_position,Vector(0,0),buttons=[]), lambda x:None)
-    assert sprite.position == mouse_position
-
-
-def test_mouse_cursor_sprite_size_reset():
-    class SpriteSubClass(MouseCursorSprite):
-        size = 3
-
-    sprite = SpriteSubClass()
-    assert sprite.size == 0 
-
-    mouse_position = Vector(123,456)
-    sprite.on_mouse_motion(events.MouseMotion(mouse_position,Vector(0,0),buttons=[]), lambda x:None)
-
-    assert sprite.size == 3

--- a/tests/test_default_sprites.py
+++ b/tests/test_default_sprites.py
@@ -147,7 +147,7 @@ def test_mouse_target_sprite():
     assert sprite.target == mouse_position
 
 
-def test_mouse_cursor_sprite():
+def test_mouse_cursor_sprite_movement():
     sprite = MouseCursorSprite()
 
     mouse_position = Vector(123,456)
@@ -155,4 +155,14 @@ def test_mouse_cursor_sprite():
     assert sprite.position == mouse_position
 
 
-    
+def test_mouse_cursor_sprite_size_reset():
+    class SpriteSubClass(MouseCursorSprite):
+        size = 3
+
+    sprite = SpriteSubClass()
+    assert sprite.size == 0 
+
+    mouse_position = Vector(123,456)
+    sprite.on_mouse_motion(events.MouseMotion(mouse_position,Vector(0,0),buttons=[]), lambda x:None)
+
+    assert sprite.size == 3


### PR DESCRIPTION
Based on https://github.com/ppb/pursuedpybear/issues/383 

MouseTargetSprite = A sprite that chases the mouse. The issue asked for this to be named `MouseMovementSprite` but I think MouseTargetSprite is a more descriptive name.  