### PR TITLE
fix diagonal movement rate

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -62,3 +62,4 @@ Halle Jones|HJones@aliacy.com||
 [Julie Fisher](https://github.com/julielinx) | | |
 [Sheena O'Connell](https://github.com/sheenarbw) | [@sheena@fosstodon.org](https://fosstodon.org/@sheena) | [blog](https://sheenaoc.com/) |
 [Quinn Redwoods](https://github.com/qredwoods) | | |
+[Jeff Epler](https://github.com/jepler) | | |

--- a/ppb/features/default_sprites.py
+++ b/ppb/features/default_sprites.py
@@ -111,7 +111,8 @@ class KeyBoardMovementSprite(ppb.Sprite):
     key_bindings = arrow_direction_key_bindings
 
     def on_update(self, update_event, signal):
-        self.position += self.direction * self.speed * update_event.time_delta
+        displacement = self.direction.scale_to(self.speed * update_event.time_delta)
+        self.position += displacement
 
     def on_key_pressed(self, key_event: KeyPressed, signal):
         if key_event.key == self.key_bindings.left:

--- a/tests/test_default_sprites.py
+++ b/tests/test_default_sprites.py
@@ -135,7 +135,7 @@ def test_keyboard_movement_sprite_move_down_left_wasd():
     keyboard_sprite.on_update(ppb.events.Update(1), lambda x: None)
 
     assert keyboard_sprite.direction.isclose((-1, -1))
-    assert keyboard_sprite.position.isclose((-1, -1))
+    assert keyboard_sprite.position.isclose((-1/2**.5, -1/2**.5))
 
 
 def test_mouse_target_sprite():


### PR DESCRIPTION
Note that `scale_to` gracefully handles the zero vector, so no special case is needed.

Jamie and I discussed and both had the gut feeling that leaving the `direction` property unchanged from now (so that its elements are still always +1, -1, or 0) was easier for implementation but could also make sense when explained.

Closes: #709